### PR TITLE
Fix broken handling for single-file sequence patterns 

### DIFF
--- a/src/fileseq/all.py
+++ b/src/fileseq/all.py
@@ -316,19 +316,43 @@ class FileSequence(object):
         return self.__padding
 
     def start(self):
+        """
+        Returns the start frame of the sequences FrameSet. 
+        Will return 0 if the sequence has no frame pattern. 
+        """
+        if self.__frameSet is None:
+            return 0
         return self.__frameSet.start()
 
     def zfill(self):
         return self.__zfill
 
     def end(self):
+        """
+        Returns the end frame of the sequences FrameSet. 
+        Will return 0 if the sequence has no frame pattern.
+        """
+        if self.__frameSet is None:
+            return 0
         return self.__frameSet.end()
 
     def frameRange(self):
-        return self.__frameSet.frameRange(self.__zfill)
+        """
+        Returns the string formatted frame range of the sequence. 
+        Will return an empty string if the sequence has no frame pattern.
+        """
+        if self.__frameSet is not None:
+            return self.__frameSet.frameRange(self.__zfill)
+        return ""
 
     def invertedFrameRange(self):
-        return self.__frameSet.invertedFrameRange(self.__zfill)
+        """
+        Returns the inverse string formatted frame range of the sequence. 
+        Will return an empty string if the sequence has no frame pattern.
+        """
+        if self.__frameSet is not None:
+            return self.__frameSet.invertedFrameRange(self.__zfill)
+        return ""
 
     def frameSet(self):
         """
@@ -378,6 +402,8 @@ class FileSequence(object):
         """
         Return the path to the file at the given index.
         """
+        if self.__frameSet is None:
+            return str(self)
         return self.frame(self.__frameSet[idx])
 
     def setDirname(self, dirname):
@@ -394,7 +420,8 @@ class FileSequence(object):
 
     def setPadding(self, padding):
         """
-        Set new padding for the sequence.
+        Set new padding characters for the sequence.
+        i.e. "#" or "@@@", or an empty string to disable range formatting.
         """
         self.__padding = padding
         self.__zfill = sum([_PADDING[c] for c in self.__padding])
@@ -420,6 +447,12 @@ class FileSequence(object):
         self.__frameSet = FrameSet(frange)
 
     def __iter__(self):
+        # If there is no frame range, or there is no padding 
+        # characters, then we only want to represent a single path
+        if self.__frameSet is None or not self.__zfill:
+            yield str(self)
+            return
+
         for f in self.__frameSet:
             yield self.frame(f)
 
@@ -427,6 +460,8 @@ class FileSequence(object):
         return self.index(idx)
 
     def __len__(self):
+        if self.__frameSet is None or not self.__zfill:
+            return 1
         return len(self.__frameSet)
 
     def __str__(self):

--- a/test/run.py
+++ b/test/run.py
@@ -228,10 +228,27 @@ class TestFileSequence(unittest.TestCase):
 		self.assertEquals("/path/to/0001.exr", seqs.index(0))
 
 	def testNoPlaceholder(self):
-		seqs = fileseq.FileSequence("/path/to/file.mov")
+		expected = "/path/to/file.mov"
+		seqs = fileseq.FileSequence(expected)
+
+		self.assertEquals(expected, seqs.index(0))
+		self.assertEquals(expected, seqs.frame(0))
+		self.assertEquals(expected, seqs[0])
+		self.assertEquals(None, seqs.frameSet())
+		self.assertEquals("", seqs.frameRange())
+		self.assertEquals("", seqs.invertedFrameRange())
+		self.assertEquals(1, len(seqs))
+
 		seqs.setFrameRange("1-100")
-		self.assertEquals("/path/to/file.mov", seqs.index(0))
-		self.assertEquals("/path/to/file.mov", seqs.frame(0))
+
+		for i in xrange(0,100):
+			self.assertEquals(expected, seqs.index(i))
+			self.assertEquals(expected, seqs.frame(i+1))
+			self.assertEquals(expected, seqs[i])
+		self.assertEquals(1, len(seqs))
+
+		seqs.setPadding("#")
+		self.assertEquals(100, len(seqs))
 
 	def testSplitXY(self):
 		seqs = fileseq.FileSequence("/cheech/0-9x1/chong.1-10#.exr")


### PR DESCRIPTION
There were recent merges that added extra support for sequence strings that represent a single file, with no padding or frame patterns. While part of the FileSequence class was updated to handle this input, various methods and functionality in the class behaved oddly when interacting with it in that state. 
len()/iteration/frameRange/start/end would crash while accessing a NoneType as the FrameSet

If you then set a FrameSet/FrameRange onto that sequence, you would get some mixed behavior. 
len would report the length of the FrameSet, but iterating over the FileSequence would produce N of the exact same string, since there is no padding.

These proposed changes address the following:
- Fix crashes when there is no FrameSet on the FileSequence and return a sane value
- Iterating over a FileSequence with no FrameSet _or_ no padding characters will yield only one string
- len(fileSequence) on a FileSequence with no FrameSet _or_ no padding characters returns 1

If it is actually still desirable produce N elements when iterating (where N == len(seq.frameSet())), then we would instead want to update the frame() method to default to a zfill of 1 when there is no padding, and then allow iter() and len() to produce more elements regardless of the zfill/padding.
