### PR TITLE
Builtins fix

### DIFF
--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -4,11 +4,10 @@ filesequence - A parsing object representing sequential files for fileseq.
 """
 from __future__ import absolute_import
 
-from builtins import next
-from builtins import filter
-from builtins import str
-from builtins import map
-from builtins import object
+try: #python 3
+    from builtins import next, filter, str, map, object #@UnresolvedImport
+except: #python 2
+    from __builtin__ import next, filter, str, map, object
 
 import future.utils as futils
 from future.utils import iteritems

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -4,8 +4,11 @@ frameset - A set-like object representing a frame range for fileseq.
 """
 from __future__ import absolute_import
 
-from builtins import str
-from builtins import map
+try: #python 3
+    from builtins import str, map
+except: #python 2
+    from __builtin__ import str, map
+    
 import future.utils
 
 import numbers

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -4,10 +4,11 @@ utils - General tools of use to fileseq operations.
 """
 from __future__ import absolute_import
 
-from builtins import bytes
-from builtins import next
-from builtins import range
-from builtins import object
+try: #python 3
+    from builtins import bytes, next, range, object #@UnresolvedImport
+except: #python 2
+    from __builtin__ import bytes, next, range, object
+
 import future.utils as futils
 
 import os


### PR DESCRIPTION
updated to latest v1.10.0 with nuke 12 on Linux/Mac, getting import error on builtins.

Simple fix to include try/except and import from __builtin__ if no builtins exist.