### PR TITLE
Update yield_sequences_in_list frame sorting to group different pad width into different sequences (refs #94)

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -10,8 +10,13 @@ import re
 # exception is raised
 MAX_FRAME_SIZE = 10000000
 
-PAD_STYLE_HASH1 = object()
-PAD_STYLE_HASH4 = object()
+
+class _PadStyle(object):
+    def __init__(self, name): self.__name = name
+    def __repr__(self): return '<PAD_STYLE: {}>'.format(self.__name)
+
+PAD_STYLE_HASH1 = _PadStyle("HASH1")
+PAD_STYLE_HASH4 = _PadStyle("HASH4")
 PAD_STYLE_DEFAULT = PAD_STYLE_HASH4
 
 PAD_MAP = {

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -741,7 +741,7 @@ class FileSequence(object):
             else:
                 seq._pad = seq._frame_pad
 
-            seq.__init__(utils.asString(seq))
+            seq.__init__(utils.asString(seq), pad_style=pad_style, allow_subframes=allow_subframes)
 
         def get_frame_width(frame_str):
             frame_num, _, _ = frame_str.partition(".")

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -732,7 +732,6 @@ class FileSequence(object):
             seq._dir = dirname or ''
             seq._base = basename or ''
             seq._ext = ext or ''
-            seq._pad_style = pad_style
             return seq
 
         def finish_new_seq(seq):

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -918,6 +918,12 @@ class TestFileSequence(TestBase):
             '8frames.08.jpg',
             '8frames.10.jpg',
             '8frames.11.jpg',
+
+            # Issue 94: ensure original padding is observed
+            'mixed_pad/file.004.jpg',
+            'mixed_pad/file.08.jpg',
+            'mixed_pad/file.009.jpg',
+            'mixed_pad/file.015.jpg',
         ]
 
         expected = {
@@ -943,6 +949,10 @@ class TestFileSequence(TestBase):
             'path/1-3#.jpg',
             '2frames.1-2@@.jpg',
             '8frames.1-2,5,7-8,10-11@@.jpg',
+
+            # Issue 94: ensure original padding is observed
+            'mixed_pad/file.8@@.jpg',
+            'mixed_pad/file.4,9,15@@@.jpg',
         }
 
         sub = self.RX_PATHSEP.sub
@@ -979,6 +989,35 @@ class TestFileSequence(TestBase):
 
         actual = {str(fs) for fs in FileSequence.yield_sequences_in_list(paths)}
 
+        for expect in expects:
+            self.assertIn(expect, actual)
+
+    def test_yield_sequences_in_list_multi_pad(self):
+        paths = [
+            'mixed_pad/file.004.jpg',
+            'mixed_pad/file.08.jpg',
+            'mixed_pad/file.009.jpg',
+            'mixed_pad/file.0013.jpg',
+            'mixed_pad/file.015.jpg',
+            'mixed_pad/file.0015.jpg',
+            'mixed_pad/file.0014.jpg',
+        ]
+
+        expects = [
+            'mixed_pad/file.8##.jpg',
+            'mixed_pad/file.4,9,15###.jpg',
+            'mixed_pad/file.13-15####.jpg',
+        ]
+        actual = {str(fs) for fs in FileSequence.yield_sequences_in_list(paths, pad_style=constants.PAD_STYLE_HASH1)}
+        for expect in expects:
+            self.assertIn(expect, actual)
+
+        expects = [
+            'mixed_pad/file.8@@.jpg',
+            'mixed_pad/file.4,9,15@@@.jpg',
+            'mixed_pad/file.13-15#.jpg',
+        ]
+        actual = {str(fs) for fs in FileSequence.yield_sequences_in_list(paths, pad_style=constants.PAD_STYLE_HASH4)}
         for expect in expects:
             self.assertIn(expect, actual)
 

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1021,6 +1021,25 @@ class TestFileSequence(TestBase):
         for expect in expects:
             self.assertIn(expect, actual)
 
+    def test_yield_sequences_in_list_pad_style(self):
+        paths = [
+            'seq/file.0001.exr',
+            'seq/file.0002.exr',
+            'seq/file.0003.exr',
+        ]
+
+        expect = 'seq/file.1-3#.exr'
+        actual = list(FileSequence.yield_sequences_in_list(paths, pad_style=fileseq.PAD_STYLE_HASH4))[0]
+        self.assertEqual(expect, str(actual))
+        self.assertEqual(fileseq.PAD_STYLE_HASH4, actual.padStyle())
+        self.assertEqual(4, actual.zfill())
+
+        expect = 'seq/file.1-3####.exr'
+        actual = list(FileSequence.yield_sequences_in_list(paths, pad_style=fileseq.PAD_STYLE_HASH1))[0]
+        self.assertEqual(expect, str(actual))
+        self.assertEqual(fileseq.PAD_STYLE_HASH1, actual.padStyle())
+        self.assertEqual(4, actual.zfill())
+
     def testIgnoreFrameSetStrings(self):
         for char in "xy:,".split():
             fs = FileSequence("/path/to/file{0}1-1x1#.exr".format(char))


### PR DESCRIPTION
Issue #94 describes a bug where a directory containing frames with different padding width end up being misrepresented as one sequence using the smallest padding width found. This isn't correct and also doesn't match the properly working behaviour in the Go and C++ implementations.

Given the following inputs:
```
/test_data/photo.004.jpg
test_data/photo.08.jpg
test_data/photo.009.jpg
test_data/photo.015.jpg
```

We expect the following sequences:
```
/test_data/photo.8@@.jpg
/test_data/photo.4,9,15@@@.jpg
```

But instead we get:
```
path/file.4,8-9,15@@.jpg
```

This merge updates the frame sorting logic in `yield_sequences_in_list` to emulate what is done in the Go counterpart:
https://github.com/justinfx/gofileseq/blob/edba74e71486ba46b295736336055873ddcc700e/sequence.go#L806

Instead of just taking all the frames and finding their smallest padding width to create a single sequence, we instead sort them by their padding widths and then create as many sequences as we need, if the frames have different padding. This takes into consideration the width (1000 = 4) and the minimum padding width (1000 = 1) when deciding if the next frame can be included in the current sequence.

