### PR TITLE
fix yield_sequences_in_list not retaining user pad_style and subframe options in sequences (refs #95)

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -10,8 +10,13 @@ import re
 # exception is raised
 MAX_FRAME_SIZE = 10000000
 
-PAD_STYLE_HASH1 = object()
-PAD_STYLE_HASH4 = object()
+
+class _PadStyle(object):
+    def __init__(self, name): self.__name = name
+    def __repr__(self): return '<PAD_STYLE: {}>'.format(self.__name)
+
+PAD_STYLE_HASH1 = _PadStyle("HASH1")
+PAD_STYLE_HASH4 = _PadStyle("HASH4")
 PAD_STYLE_DEFAULT = PAD_STYLE_HASH4
 
 PAD_MAP = {

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -756,7 +756,7 @@ class FileSequence(object):
             else:
                 seq._pad = seq._frame_pad
 
-            seq.__init__(utils.asString(seq))
+            seq.__init__(utils.asString(seq), pad_style=pad_style, allow_subframes=allow_subframes)
             yield seq
 
     @classmethod

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -982,6 +982,25 @@ class TestFileSequence(TestBase):
         for expect in expects:
             self.assertIn(expect, actual)
 
+    def test_yield_sequences_in_list_pad_style(self):
+        paths = [
+            'seq/file.0001.exr',
+            'seq/file.0002.exr',
+            'seq/file.0003.exr',
+        ]
+
+        expect = 'seq/file.1-3#.exr'
+        actual = list(FileSequence.yield_sequences_in_list(paths, pad_style=fileseq.PAD_STYLE_HASH4))[0]
+        self.assertEqual(expect, str(actual))
+        self.assertEqual(fileseq.PAD_STYLE_HASH4, actual.padStyle())
+        self.assertEqual(4, actual.zfill())
+
+        expect = 'seq/file.1-3####.exr'
+        actual = list(FileSequence.yield_sequences_in_list(paths, pad_style=fileseq.PAD_STYLE_HASH1))[0]
+        self.assertEqual(expect, str(actual))
+        self.assertEqual(fileseq.PAD_STYLE_HASH1, actual.padStyle())
+        self.assertEqual(4, actual.zfill())
+
     def testIgnoreFrameSetStrings(self):
         for char in "xy:,".split():
             fs = FileSequence("/path/to/file{0}1-1x1#.exr".format(char))


### PR DESCRIPTION
Fixes #95 

`yield_sequences_in_list` was not passing along the `pad_style` and `allow_subframes`  options when initializing each sequence. This caused the sequence to have the default (HASH4) pad style and to ignore subframes. 

Also a small tweak in this merge is to make the pad style constants have a helpful repr to make debugging the value a bit easier.