### PR TITLE
Batching api - batch generators for frames and sequences

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,3 +35,11 @@ fileseq.frameset module
     :special-members: __and__, __contains__, __eq__, __ge__, __getitem__, __getstate__, __gt__,
         __hash__, __iter__, __le__, __len__, __lt__, __ne__, __or__, __rand__, __repr__,
         __reversed__, __ror__, __rsub__, __rxor__, __setstate__, __str__, __sub__, __xor__
+
+fileseq.utils module
+-------------------------
+
+.. automodule:: fileseq.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -580,6 +580,19 @@ class FileSequence(object):
         """
         return self.__getitem__(idx)
 
+    def batches(self, batch_size):
+        """
+        Returns a generator that yields groups of file paths, up to ``batch_size``.
+        Convenience method for ``fileseq.utils.batchIterable(self, batch_size)``
+
+        Args:
+            batch_size (int): max file paths in each batch
+
+        Returns:
+            generator: yields batches of file paths in sequence
+        """
+        return utils.batchIterable(self, batch_size)
+
     def __setstate__(self, state):
         """
         Allows for de-serialization from a pickled :class:`FileSequence`.

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -12,9 +12,9 @@ import decimal
 import numbers
 
 try:  # > PY2
-    from collections.abc import Set, Sequence
+    from collections.abc import Set, Sized, Iterable
 except ImportError:  # PY2
-    from collections import Set, Sequence
+    from collections import Set, Sized, Iterable
 
 from fileseq import constants # constants.MAX_FRAME_SIZE updated during tests
 from fileseq.constants import PAD_MAP, FRANGE_RE, PAD_RE
@@ -137,7 +137,7 @@ class FrameSet(Set):
                     self.framesToFrameRange, self._order, sort=False, compress=False)
                 return
             # if it's ordered, find unique and build
-            elif isinstance(frange, Sequence):
+            elif isinstance(frange, Sized) and isinstance(frange, Iterable):
                 self._maxSizeCheck(frange)
                 items = set()
                 order = unique(items, catch_parse_err(normalizeFrames, frange))
@@ -301,7 +301,7 @@ class FrameSet(Set):
     @classmethod
     def from_range(cls, start, end, step=1):
         """
-        Build a :class:`FrameSet` from given start and end frames.
+        Build a :class:`FrameSet` from given start and end frames (inclusive).
 
         Args:
             start (int): The first frame of the :class:`FrameSet`.
@@ -528,18 +528,26 @@ class FrameSet(Set):
         return FrameSet(FrameSet.framesToFrameRange(
             self.items, sort=True, compress=False))
 
-    def batches(self, batch_size):
+    def batches(self, batch_size, frames=False):
         """
-        Returns a generator that yields groups of frame numbers, up to ``batch_size``.
-        Convenience method for ``fileseq.utils.batchIterable(self, batch_size)``
+        Returns a generator that yields sub-batches of frames, up to ``batch_size``.
+        If ``frames=False``, each batch is a new ``FrameSet`` subrange.
+        If ``frames=True``, each batch is an islice generator object of the sub-range.
 
         Args:
             batch_size (int): max frame values in each batch
+            frames (bool): if True, generate islice sub-ranges instead of FrameSets
 
         Returns:
-            generator: yields batches of frames
+            generator: yields batches of islice or FrameSet sub-ranges
         """
-        return batchIterable(self, batch_size)
+        batch_it = batchIterable(self, batch_size)
+        if frames:
+            # They just want batches of the frame values
+            return batch_it
+
+        # return batches of FrameSet instance
+        return (self.from_iterable(b) for b in batch_it)
 
     def __getstate__(self):
         """

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -19,7 +19,8 @@ except ImportError:  # PY2
 from fileseq import constants # constants.MAX_FRAME_SIZE updated during tests
 from fileseq.constants import PAD_MAP, FRANGE_RE, PAD_RE
 from fileseq.exceptions import MaxSizeException, ParseException
-from fileseq.utils import asString, xfrange, unique, pad, quantize, normalizeFrame, normalizeFrames
+from fileseq.utils import asString, xfrange, unique, pad, quantize, normalizeFrame, normalizeFrames, \
+                          batchIterable
 
 # Issue #44
 # Possibly use an alternate range implementation, depending on platform.
@@ -526,6 +527,19 @@ class FrameSet(Set):
         """
         return FrameSet(FrameSet.framesToFrameRange(
             self.items, sort=True, compress=False))
+
+    def batches(self, batch_size):
+        """
+        Returns a generator that yields groups of frame numbers, up to ``batch_size``.
+        Convenience method for ``fileseq.utils.batchIterable(self, batch_size)``
+
+        Args:
+            batch_size (int): max frame values in each batch
+
+        Returns:
+            generator: yields batches of frames
+        """
+        return batchIterable(self, batch_size)
 
     def __getstate__(self):
         """

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -68,7 +68,7 @@ class xrange2(object):
     for checking the length of the range.
     """
 
-    __slots__ = ['_len', '_islice']
+    __slots__ = ['_len', '_islice', '_start', '_stop', '_step']
 
     def __init__(self, start, stop=None, step=1):
         if stop is None:
@@ -76,6 +76,15 @@ class xrange2(object):
 
         self._len = lenRange(start, stop, step)
         self._islice = islice(count(start, step), self._len)
+        self._start = start
+        self._stop = stop
+        self._step = step
+
+    def __repr__(self):
+        if self._step == 1:
+            return 'range({}, {})'.format(self._start, self._stop)
+        else:
+            return 'range({}, {}, {})'.format(self._start, self._stop, self._step)
 
     def __len__(self):
         return self._len
@@ -85,6 +94,18 @@ class xrange2(object):
 
     def __iter__(self):
         return self._islice.__iter__()
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def stop(self):
+        return self._stop
+
+    @property
+    def step(self):
+        return self._step
 
 
 # Issue #44

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -123,6 +123,87 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(actual, str)
         self.assertNotIsInstance(actual, _CustomPathString)
 
+    def testBatchFrames(self):
+        Case = namedtuple('Case', ['start', 'stop', 'batches', 'expect'])
+        table = [
+            Case(1,  5, -1, []),
+            Case(1,  5,  0, []),
+            Case(1,  5,  1, [[1], [2], [3], [4], [5]]),
+            Case(1,  5,  2, [[1,2], [3,4], [5]]),
+            Case(1,  5,  3, [[1,2,3], [4,5]]),
+            Case(1,  5,  4, [[1,2,3,4], [5]]),
+            Case(1,  5,  5, [[1,2,3,4,5]]),
+            Case(1,  5,  9, [[1,2,3,4,5]]),
+            Case(2, 13,  3, [[2,3,4], [5,6,7], [8,9,10], [11,12,13]]),
+            Case(2, 13,  4, [[2,3,4,5], [6,7,8,9], [10,11,12,13]]),
+
+            Case( 5, 1, 1, [[5], [4], [3], [2], [1]]),
+            Case(13, 2, 2, [[13,12], [11,10], [9,8], [7,6], [5,4], [3,2]]),
+            Case(13, 2, 3, [[13,12,11], [10,9,8], [7,6,5], [4,3,2]]),
+            Case(13, 2, 4, [[13,12,11,10], [9,8,7,6], [5,4,3,2]]),
+            Case(13, 2, 5, [[13,12,11,10,9], [8,7,6,5,4], [3,2]]),
+            Case(13, 2, 6, [[13,12,11,10,9,8], [7,6,5,4,3,2]]),
+            Case(13, 1, 6, [[13,12,11,10,9,8], [7,6,5,4,3,2], [1]]),
+        ]
+
+        for case in table:
+            actual = utils.batchFrames(case.start, case.stop, case.batches)
+            actual = [list(i) for i in actual]
+            self.assertEqual(case.expect, actual, msg=str(case))
+
+    def testBatchIterable(self):
+        Case = namedtuple('Case', ['it', 'batches', 'expect'])
+        table = [
+            Case(['a', 'b', 'c'],   0, []),
+            Case(['a', 'b', 'c'],  -1, []),
+            Case(['a', 'b', 'c'],   1, [['a'], ['b'], ['c']]),
+            Case(['a', 'b', 'c'],   2, [['a', 'b'], ['c']]),
+            Case(['a', 'b', 'c'],   3, [['a', 'b', 'c']]),
+            Case(['a', 'b', 'c'],   9, [['a', 'b', 'c']]),
+
+            Case('abc',  0, []),
+            Case('abc',  1, [['a'], ['b'], ['c']]),
+            Case('abc',  2, [['a', 'b'], ['c']]),
+            Case('abc',  3, [['a', 'b', 'c']]),
+            Case('abc',  9, [['a', 'b', 'c']]),
+
+            Case(range(1,5),  0, []),
+            Case(range(1,5),  1, [[1], [2], [3], [4]]),
+            Case(range(1,5),  2, [[1,2], [3,4]]),
+            Case(range(1,5),  3, [[1,2,3], [4]]),
+            Case(range(1,5),  4, [[1,2,3,4]]),
+            Case(range(1,5),  5, [[1,2,3,4]]),
+            Case(range(1,5),  9, [[1,2,3,4]]),
+        ]
+
+        def gen(): return (i for i in 'abc')
+        table += [
+            Case(gen(),  0, []),
+            Case(gen(),  1, [['a'], ['b'], ['c']]),
+            Case(gen(),  2, [['a', 'b'], ['c']]),
+            Case(gen(),  3, [['a', 'b', 'c']]),
+            Case(gen(),  4, [['a', 'b', 'c']]),
+            Case(gen(),  9, [['a', 'b', 'c']]),
+        ]
+
+        def _iter(): return iter([1,2,3,4,5,6,7])
+        table += [
+            Case(_iter(),  0, []),
+            Case(_iter(),  1, [[1], [2], [3], [4], [5], [6], [7]]),
+            Case(_iter(),  2, [[1,2], [3,4], [5,6], [7]]),
+            Case(_iter(),  3, [[1,2,3], [4,5,6], [7]]),
+            Case(_iter(),  4, [[1,2,3,4], [5,6,7]]),
+            Case(_iter(),  5, [[1,2,3,4,5], [6,7]]),
+            Case(_iter(),  6, [[1,2,3,4,5,6], [7]]),
+            Case(_iter(),  7, [[1,2,3,4,5,6,7]]),
+            Case(_iter(),  9, [[1,2,3,4,5,6,7]]),
+        ]
+
+        for case in table:
+            actual = utils.batchIterable(case.it, case.batches)
+            actual = [list(i) for i in actual]
+            self.assertEqual(case.expect, actual, msg=str(case))
+
 
 class TestFrameSet(unittest.TestCase):
 

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -198,6 +198,7 @@ class TestUtils(unittest.TestCase):
 
     def testBatchIterable(self):
         Case = namedtuple('Case', ['it', 'batches', 'expect'])
+        _range = range  # prevent pylint warning W1638
         table = [
             Case(['a', 'b', 'c'],   0, []),
             Case(['a', 'b', 'c'],  -1, []),
@@ -212,13 +213,13 @@ class TestUtils(unittest.TestCase):
             Case('abc',  3, [['a', 'b', 'c']]),
             Case('abc',  9, [['a', 'b', 'c']]),
 
-            Case(range(1,5),  0, []),
-            Case(range(1,5),  1, [[1], [2], [3], [4]]),
-            Case(range(1,5),  2, [[1,2], [3,4]]),
-            Case(range(1,5),  3, [[1,2,3], [4]]),
-            Case(range(1,5),  4, [[1,2,3,4]]),
-            Case(range(1,5),  5, [[1,2,3,4]]),
-            Case(range(1,5),  9, [[1,2,3,4]]),
+            Case(_range(1,5),  0, []),
+            Case(_range(1,5),  1, [[1], [2], [3], [4]]),
+            Case(_range(1,5),  2, [[1,2], [3,4]]),
+            Case(_range(1,5),  3, [[1,2,3], [4]]),
+            Case(_range(1,5),  4, [[1,2,3,4]]),
+            Case(_range(1,5),  5, [[1,2,3,4]]),
+            Case(_range(1,5),  9, [[1,2,3,4]]),
         ]
 
         def gen(): return (i for i in 'abc')


### PR DESCRIPTION
It would be useful if fileseq provided a way to generate batches in an efficient way.  The API could provide batch functions that can take frame ranges or iterables and a batch size, and return a generator that yields batches of slices. This could be useful for applications that deal with rendering or other distributed tasks that want to break up ranges into batched tasks.

The top level functions in this MR are:

- `utils.batchFrames(start, stop, batch_size)` - takes an inclusive frame range and generates slices of up to `batch_size`
- `utils.batchIterable(it, batch_size)` - takes an interable and generates slices of up to `batch_size`

For `batchIterable`, if the iterable can report its length then a more efficient code-path can be taken. Otherwise if it is an opaque generator, it has to be iterated to build batches on each yield.

With these two functions, helper methods have been added:

- `FrameSet.batches(batch_size, frames=False)`
- `FileSequence.batches(batch_size, paths=False)`

`FrameSet.batches` will generate new `FrameSet` subranges up to the `batch_size`. If `frames=True` it will instead generate batches of `islice` types, which are iterable ranges that can repor their length, start, and stop.

`FileSequence.batches` is similar, in that it will generates new `FileSequence` subranges up to the `batch_size`. If `paths=True` it will instead generate lists of the individual frame paths.

See the tests for examples.