### PR TITLE
Fix for negative zero

### DIFF
--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -404,8 +404,10 @@ def pad(number, width=0, decimal_places=None):
     # See _DeriveClipTimeString for formating of templateAssetPath
     # https://github.com/PixarAnimationStudios/USD/blob/release/pxr/usd/usd/clipSetDefinition.cpp
     if decimal_places == 0:
-        if not isinstance(number, str):
+        try:
             number = round(number)
+        except TypeError:
+            pass
         return futils.native_str(number).partition(".")[0].zfill(width)
 
     # USD ultimately uses vsnprintf to format floats for templateAssetPath:

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -398,6 +398,7 @@ def pad(number, width=0, decimal_places=None):
     Returns:
         str:
     """
+
     # Make the common case fast. Truncate to integer value as USD does.
     # https://graphics.pixar.com/usd/docs/api/_usd__page__value_clips.html
     # See _DeriveClipTimeString for formating of templateAssetPath

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -35,7 +35,10 @@ def quantize(number, decimal_places, rounding=decimal.ROUND_HALF_EVEN):
         decimal.Decimal:
     """
     quantize_exponent = decimal.Decimal(1).scaleb(-decimal_places)
-    return number.quantize(quantize_exponent, rounding=rounding)
+    nq = number.quantize(quantize_exponent, rounding=rounding)
+    if nq.is_zero():
+        return nq.copy_abs()
+    return nq
 
 
 def lenRange(start, stop, step=1):

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -391,19 +391,20 @@ def pad(number, width=0, decimal_places=None):
     Return the zero-padded string of a given number.
 
     Args:
-        number (int, float, or decimal.Decimal): the number to pad
+        number (str, int, float, or decimal.Decimal): the number to pad
         width (int): width for zero padding the integral component
         decimal_places (int): number of decimal places to use in frame range
 
     Returns:
         str:
     """
-
     # Make the common case fast. Truncate to integer value as USD does.
     # https://graphics.pixar.com/usd/docs/api/_usd__page__value_clips.html
     # See _DeriveClipTimeString for formating of templateAssetPath
     # https://github.com/PixarAnimationStudios/USD/blob/release/pxr/usd/usd/clipSetDefinition.cpp
     if decimal_places == 0:
+        if not isinstance(number, str):
+            number = round(number)
         return futils.native_str(number).partition(".")[0].zfill(width)
 
     # USD ultimately uses vsnprintf to format floats for templateAssetPath:

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1106,6 +1106,13 @@ class TestFileSequence(TestBase):
         self.assertEquals(fs.extension(), '.exr')
         self.assertEquals(str(fs), "/path/to/file.1920x1038.1001-1002x0.25@.#.exr")
 
+    def testSubframeNotNegativeZero(self):
+        # test that a small negative subframe rounds to 0 (and not -0)
+        fs = FileSequence("#", allow_subframes=True)
+        self.assertEquals(fs.frame(-0.00000001), "0000")
+        fs = FileSequence("#.#", allow_subframes=True)
+        self.assertEquals(fs.frame(-0.00000001), "0000.0000")
+
     def testNoFrameNoVersionNoExt(self):
         for allow_subframes in [False, True]:
             fs = FileSequence("/path/to/file", allow_subframes=allow_subframes)


### PR DESCRIPTION
Fix for https://github.com/justinfx/fileseq/issues/123

While testing, I found that the `utils.pad` function sometimes is catching a `str` number, so I had to guard against that usecase.