### PR TITLE
FileSequence: Set a default pad char when a range is set for the first time (refs #127)

### DIFF
--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -53,6 +53,8 @@ class FileSequence:
     SPLIT_RE = SPLIT_RE
     SPLIT_SUB_RE = SPLIT_SUB_RE
 
+    _DEFAULT_PAD_CHAR = '@'
+
     def __init__(self,
                  sequence: str,
                  pad_style: constants._PadStyle = PAD_STYLE_DEFAULT,
@@ -430,6 +432,9 @@ class FileSequence:
                 ])
         self._frameSet = frameSet
 
+        if not self._pad:
+            self.setPadding(self._DEFAULT_PAD_CHAR)
+
     def extension(self) -> str:
         """
         Return the file extension of the sequence, including leading period.
@@ -485,6 +490,8 @@ class FileSequence:
             frange (str): a properly formatted frame range, as per :class:`.FrameSet`
         """
         self._frameSet = FrameSet(frange)
+        if not self._pad:
+            self.setPadding(self._DEFAULT_PAD_CHAR)
 
     def invertedFrameRange(self) -> str:
         """


### PR DESCRIPTION
Per #127, set a default pad char on a `FileSequence` when a range is set for the first time and no pad char has been set.

Breaking change, as previous behavior would create unexpected output formatting:
```
> fs = fileseq.FileSequence("foo.exr")
> fs.setFrameRange("1-3")
> list(fs)
['foo1-3.exr']
```

Whereas, after this change, a default pad char is set:
```
> fs = fileseq.FileSequence("foo.exr")
> fs.setFrameRange("1-3")
> list(fs)
['foo1.exr', 'foo2.exr', 'foo3.exr']
```