### PR TITLE
Detect and preserve path separators for cross-platform support (refs #145)

### DIFF
--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -100,6 +100,9 @@ class BaseFileSequence(typing.Generic[T]):
         """
         sequence = utils.asString(sequence)
 
+        # Detect and store the path separator from input
+        self._sep = utils._getPathSep(sequence)
+
         if not skip_parse and not hasattr(self, '_frameSet'):
 
             self._frameSet = None
@@ -195,12 +198,22 @@ class BaseFileSequence(typing.Generic[T]):
 
         Args:
             path_str (str): The path as a string
-            
+
         Returns:
             T: The path in the appropriate type for this sequence
         """
         raise NotImplementedError("Subclasses must implement _create_path")
-    
+
+    @property
+    def _sep(self) -> str:
+        """Path separator, defaults to os.sep if not explicitly set."""
+        sep = self.__dict__.get('_sep')
+        return sep if sep is not None else os.sep
+
+    @_sep.setter
+    def _sep(self, value: str) -> None:
+        self.__dict__['_sep'] = value
+
     def copy(self) -> Self:
         """
         Create a deep copy of this sequence
@@ -290,13 +303,20 @@ class BaseFileSequence(typing.Generic[T]):
         """
         Set a new directory name for the sequence.
 
+        The path separator will be detected from the new dirname,
+        allowing you to change the path style (POSIX ↔ Windows).
+
         Args:
             dirname (str): the new directory name
         """
         # Make sure the dirname always ends in
         # a path separator character
         dirname = utils.asString(dirname)
-        sep = utils._getPathSep(dirname)
+
+        # Detect separator from the new dirname
+        # This allows changing path semantics
+        sep = self._sep = utils._getPathSep(dirname)
+
         if not dirname.endswith(sep):
             dirname = str(dirname) + sep
 
@@ -975,6 +995,9 @@ class BaseFileSequence(typing.Generic[T]):
             seq._dir = dirname or ''
             seq._base = basename or ''
             seq._ext = ext or ''
+            # Detect separator from dirname (which came from parsed paths)
+            if dirname:
+                seq._sep = utils._getPathSep(dirname)
             return seq
 
         def finish_new_seq(seq: Self) -> None:

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -452,20 +452,26 @@ def pad(number: typing.Any, width: typing.Optional[int] = 0, decimal_places: typ
 
 def _getPathSep(path: str) -> str:
     """
-    Abstracts returning the appropriate path separator
-    for the given path string.
+    Detect the path separator used in the given path string.
 
-    This implementation always returns ``os.sep``
-
-    Abstracted to make test mocking easier.
+    Counts occurrences of '/' vs '\\' and returns the most common.
+    Returns os.sep if no separators are found.
 
     Args:
         path (str): A path to check for the most common sep
 
     Returns:
-        str:
+        str: '/' or '\\' (or os.sep as fallback)
     """
-    return os.sep
+    forward_count = path.count('/')
+    backward_count = path.count('\\')
+
+    if forward_count > backward_count:
+        return '/'
+    elif backward_count > forward_count:
+        return '\\'
+    else:
+        return os.sep
 
 
 _STR_TYPES = frozenset((str, bytes))

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -69,7 +69,7 @@ def _getCommonPathSep(path):
     return sep
 
 
-utils._getPathSep = _getCommonPathSep
+# No longer need to mock _getPathSep - it now detects separators natively
 
 
 class TestUtils(unittest.TestCase):
@@ -918,6 +918,93 @@ class AbstractBaseTests:
             seq = self.FS("/foo/bong.1-5@.exr")
             seq.setBasename("bar.")
             self.assertEquals(self.FILE("/foo/bar.1.exr"), seq[0])
+
+        def testSeparatorDetection(self):
+            # POSIX paths
+            seq = self.FS("/mnt/Shows/test.1-100#.exr")
+            self.assertEqual(seq._sep, '/')
+
+            # Windows paths
+            seq = self.FS("Z:\\Shows\\test.1-100#.exr")
+            self.assertEqual(seq._sep, '\\')
+
+            # Mixed (forward wins)
+            seq = self.FS("/mnt/Shows\\test/file.#.exr")
+            self.assertEqual(seq._sep, '/')
+
+            # Equal counts (fallback to os.sep)
+            seq = self.FS("foo/bar\\baz.#.exr")
+            self.assertEqual(seq._sep, os.sep)
+
+            # No separators
+            seq = self.FS("test.1-100#.exr")
+            self.assertEqual(seq._sep, os.sep)
+
+        def testSeparatorPreservation(self):
+            # POSIX
+            seq = self.FS("/mnt/Shows/test.1-100#.exr")
+            self.assertEqual(str(seq), "/mnt/Shows/test.1-100#.exr")
+            self.assertEqual(str(seq[0]), "/mnt/Shows/test.0001.exr")
+
+            # Windows
+            seq = self.FS("Z:\\Shows\\test.1-100#.exr")
+            self.assertEqual(str(seq), "Z:\\Shows\\test.1-100#.exr")
+            self.assertEqual(str(seq[0]), "Z:\\Shows\\test.0001.exr")
+
+        def testSetDirnameDetectsSeparator(self):
+            # POSIX sequence keeps POSIX separator when setting POSIX dirname
+            seq = self.FS("/foo/bar.1-5#.exr")
+            seq.setDirname("/baz/qux")
+            self.assertEqual(seq._sep, '/')
+            self.assertEqual(seq.dirname(), "/baz/qux/")
+            self.assertEqual(str(seq[0]), "/baz/qux/bar.0001.exr")
+
+            # Changing separator is detected from new dirname
+            seq = self.FS("/foo/bar.1-5#.exr")
+            self.assertEqual(seq._sep, '/')
+            seq.setDirname("C:\\Windows\\Path")
+            self.assertEqual(seq._sep, '\\')
+            # Note: basename still has POSIX format from original parse
+            # Full cross-platform reconstruction is limited by os.path.split()
+
+        def testCopyPreservesSeparator(self):
+            seq = self.FS("/mnt/Shows/test.1-100#.exr")
+            seq2 = seq.copy()
+            self.assertEqual(seq2._sep, '/')
+            self.assertEqual(str(seq2), str(seq))
+
+            seq = self.FS("Z:\\Shows\\test.1-100#.exr")
+            seq2 = seq.copy()
+            self.assertEqual(seq2._sep, '\\')
+            self.assertEqual(str(seq2), str(seq))
+
+        def testSplitPreservesSeparator(self):
+            seq = self.FS("/mnt/Shows/test.1-100#.exr")
+            parts = seq.split()
+            for part in parts:
+                self.assertEqual(part._sep, '/')
+                self.assertTrue(str(part).startswith('/'))
+
+            seq = self.FS("Z:\\Shows\\test.1-100#.exr")
+            parts = seq.split()
+            for part in parts:
+                self.assertEqual(part._sep, '\\')
+                self.assertTrue(str(part).startswith('Z:'))
+
+        def testSerializationPreservesSeparator(self):
+            # POSIX path
+            seq = self.FS("/mnt/Shows/test.1-100#.exr")
+            state = seq.to_dict()
+            seq2 = self.FS.from_dict(state)
+            self.assertEqual(seq2._sep, '/')
+            self.assertEqual(str(seq2), str(seq))
+
+            # Windows path
+            seq = self.FS("Z:\\Shows\\test.1-100#.exr")
+            state = seq.to_dict()
+            seq2 = self.FS.from_dict(state)
+            self.assertEqual(seq2._sep, '\\')
+            self.assertEqual(str(seq2), str(seq))
 
         def testSetPadding(self):
             seq = self.FS("/foo/bong.1-5@.exr")


### PR DESCRIPTION
Fixes #145 by detecting and preserving path separators from the input instead of forcing everything
to match the host OS.

The problem was that `utils._getPathSep()` always returned `os.sep`, which broke cross-platform
workflows where you might be working with Windows paths on Linux or vice versa.

Changes:
- Updated `utils._getPathSep()` to detect `/` vs `\` based on which appears most frequently
- Added `_sep` as a property on `FileSequence` that stores the detected separator and defaults to
`os.sep`
- `setDirname()` now detects the separator from the new dirname, allowing you to change path styles
if needed
- `findSequencesOnDisk()` still uses `os.sep` for results since they represent actual local files

Mixed separators use whichever is most common, no warnings/errors. Backward compatible - old
serialized objects get `os.sep` via the property default.
