### PR TITLE
Add _preprocess_sequence hook for custom FileSequence subclasses (fixes #139)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Fileseq Changelog
 
+## v3.2.0 (2026-04-19)
+
+* Add pre/post processing hooks for custom FileSequence subclasses to control input/output string formats (#154)
+
 ## v3.1.1 (2026-03-13)
 
 * grammar: fix directory rule to allow UNC paths (//server/share/) (#153)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v3.2.0 (2026-04-19)
 
 * Add pre/post processing hooks for custom FileSequence subclasses to control input/output string formats (#154)
+* Create new Usage doc
 
 ## v3.1.1 (2026-03-13)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ A Python library for parsing frame ranges and file sequences commonly used in VF
    :maxdepth: 2
    :caption: Contents:
 
+   usage
    api
    grammar
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -227,6 +227,38 @@ Three class methods locate sequences on disk.
                                           strictPadding=True,
                                           preserve_padding=True)
 
+**Using a custom subclass with the find methods**
+
+All three find methods are classmethods, so the simplest way to get results of a
+custom subclass is to call the method directly on that subclass.  The
+``_preprocess_sequence`` and ``_postprocess_sequence`` hooks are picked up
+automatically:
+
+.. code-block:: python
+
+    # Call directly on the subclass — hooks are used automatically
+    seqs = VRayFileSequence.findSequencesOnDisk('/renders')
+    seq  = VRayFileSequence.findSequenceOnDisk('/renders/beauty.<frame04>.exr',
+                                               strictPadding=True,
+                                               preserve_padding=True)
+    seqs = VRayFileSequence.findSequencesInList(paths)
+
+When the call site cannot be changed — for example in a generic utility that
+always calls ``FileSequence.findSequenceOnDisk`` — pass the subclass via the
+``klass`` argument instead:
+
+.. code-block:: python
+
+    # klass overrides which class is used to construct results
+    seqs = FileSequence.findSequencesOnDisk('/renders', klass=VRayFileSequence)
+    seq  = FileSequence.findSequenceOnDisk('/renders/beauty.<frame04>.exr',
+                                           strictPadding=True,
+                                           preserve_padding=True,
+                                           klass=VRayFileSequence)
+    seqs = FileSequence.findSequencesInList(paths, klass=VRayFileSequence)
+
+Both approaches produce identical results.
+
 **findSequencesInList** — build sequences from an existing file list in memory
 
 This is useful when you already have a list of paths (e.g. from an asset database) and do not

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,411 @@
+Usage Guide
+===========
+
+This guide covers practical usage of the two main classes — :class:`~fileseq.FrameSet` and
+:class:`~fileseq.FileSequence` — as well as the filesystem discovery functions and how to
+extend the library through subclassing.
+
+FrameSet
+--------
+
+A :class:`~fileseq.FrameSet` holds an ordered, deduplicated set of frame numbers parsed from a
+range string.  It behaves like an immutable sequence and supports set-algebra operators.
+
+**Range syntax**
+
+.. code-block:: python
+
+    from fileseq import FrameSet
+
+    FrameSet('1-10')          # 1, 2, 3, …, 10
+    FrameSet('1-10x2')        # step: 1, 3, 5, 7, 9
+    FrameSet('1-10y2')        # fill (inverse step): 2, 4, 6, 8, 10
+    FrameSet('1-10:3')        # stagger: 1-10x3, 1-10x2, 1-10
+    FrameSet('-5-5')          # negative frames: -5, -4, …, 5
+    FrameSet('1-5,10-20')     # comma-separated ranges
+
+**Constructing from iterables or a single frame**
+
+.. code-block:: python
+
+    FrameSet([1, 2, 3, 4, 5])
+    FrameSet(42)              # single frame
+    FrameSet(FrameSet('1-5')) # copy constructor
+
+**Subframe support**
+
+Pass ``Decimal`` values or a subframe range string to work with fractional frame numbers:
+
+.. code-block:: python
+
+    from fileseq import FrameSet
+
+    FrameSet('1-3x0.5')          # 1.0, 1.5, 2.0, 2.5, 3.0
+    FrameSet([0, 0.25, 0.5, 1])  # from an iterable of floats
+
+**Iteration and indexing**
+
+.. code-block:: python
+
+    fs = FrameSet('1-10x2')
+
+    list(fs)    # [1, 3, 5, 7, 9]
+    fs[0]       # 1
+    fs[-1]      # 9
+    len(fs)     # 5
+    5 in fs     # True
+
+**Set operations**
+
+.. code-block:: python
+
+    a = FrameSet('1-5')
+    b = FrameSet('3-7')
+
+    a | b  # union:        1-7
+    a & b  # intersection: 3-5
+    a - b  # difference:   1-2
+    a ^ b  # symmetric difference: 1-2, 6-7
+
+**String representation**
+
+.. code-block:: python
+
+    str(FrameSet('1-10x2'))          # '1-9x2'
+    FrameSet('1-5,10-20').frameRange # '1-5,10-20'
+
+FileSequence
+------------
+
+A :class:`~fileseq.FileSequence` represents a path pattern paired with a frame range and a
+padding token.
+
+**Pattern syntax**
+
+.. code-block:: text
+
+    /path/to/name.{framerange}{padding}.ext
+
+Supported padding tokens:
+
+===========  ========================================================
+Token        Width
+===========  ========================================================
+``#``        4 digits (``%04d``)
+``@@@@``     4 digits
+``@``        1 digit
+``%04d``     printf-style (any width)
+``$F4``      Houdini-style (any width)
+``<UDIM>``   UDIM tile identifier (no padding)
+===========  ========================================================
+
+**Basic construction**
+
+.. code-block:: python
+
+    from fileseq import FileSequence
+
+    seq = FileSequence('/render/beauty.1-100#.exr')
+    print(seq.basename())    # 'beauty'
+    print(seq.extension())   # '.exr'
+    print(seq.padding())     # '#'
+    print(seq.frameRange())  # '1-100'
+
+**Accessing individual frames**
+
+.. code-block:: python
+
+    seq = FileSequence('/render/beauty.1-10#.exr')
+
+    seq.frame(1)    # '/render/beauty.0001.exr'
+    seq[0]          # first frame path (same as seq.frame(seq.start()))
+    list(seq)       # all 10 file paths as strings
+
+**Alternative padding styles**
+
+.. code-block:: python
+
+    FileSequence('/render/beauty.1-10@@@.exr')    # 3-digit padding
+    FileSequence('/render/beauty.1-10%04d.exr')   # printf-style
+    FileSequence('/render/beauty.1-10$F4.exr')    # Houdini-style
+
+**Non-frame files**
+
+A sequence with no frame range is valid:
+
+.. code-block:: python
+
+    seq = FileSequence('/render/config.json')
+    seq.frameRange()  # ''
+    seq.frame('')     # '/render/config.json'
+
+**Pad style — HASH4 (default) vs HASH1 (ie Houdini)**
+
+.. code-block:: python
+
+    from fileseq import FileSequence, PAD_STYLE_DEFAULT, PAD_STYLE_HASH1
+
+    # Default: '#' maps to 4-digit zero-padded
+    seq = FileSequence('/out/f.1-10#.exr', pad_style=PAD_STYLE_DEFAULT)
+
+    # Hash1: '#' maps to 1 digit, '####' to 4 digits (Houdini convention)
+    seq = FileSequence('/out/f.1-10#.exr', pad_style=PAD_STYLE_HASH1)
+
+**Subframe sequences**
+
+Subframe support in a sequence pattern must be explicitly enabled, to avoid ambiguous parsing:
+
+.. code-block:: python
+
+    seq = FileSequence('/render/beauty.1-2x0.5#.#.exr', allow_subframes=True)
+    list(seq)
+    # ['/render/beauty.0001.0000.exr',
+    #  '/render/beauty.0001.5000.exr',
+    #  '/render/beauty.0002.0000.exr']
+
+**Formatting**
+
+:meth:`~fileseq.FileSequence.format` accepts a template string with named fields:
+
+.. code-block:: python
+
+    seq = FileSequence('/show/shot/beauty.1-100#.exr')
+    seq.format('{dirname}{basename}{range}{padding}{extension}')
+    # '/show/shot/beauty.1-100#.exr'
+
+    seq.format('{basename}{extension}')  # 'beauty.exr'
+
+**pathlib variant**
+
+:class:`~fileseq.FilePathSequence` is identical to :class:`~fileseq.FileSequence` but returns
+:class:`pathlib.Path` objects from iteration and :meth:`frame`:
+
+.. code-block:: python
+
+    from fileseq import FilePathSequence
+
+    seq = FilePathSequence('/render/beauty.1-10#.exr')
+    type(seq.frame(1))  # <class 'pathlib.PosixPath'>
+
+Filesystem Discovery
+--------------------
+
+Three class methods locate sequences on disk.
+
+**findSequencesOnDisk** — scan a directory
+
+.. code-block:: python
+
+    from fileseq import FileSequence
+
+    # All sequences in a directory
+    seqs = FileSequence.findSequencesOnDisk('/show/shot/renders/v001')
+    for s in seqs:
+        print(s)
+
+    # Include hidden files (names starting with '.')
+    seqs = FileSequence.findSequencesOnDisk('/renders', include_hidden=True)
+
+    # Strict padding: only match files whose digit count equals the padding token width
+    seqs = FileSequence.findSequencesOnDisk('/renders', strictPadding=True)
+
+    # Subframe sequences
+    seqs = FileSequence.findSequencesOnDisk('/renders', allow_subframes=True)
+
+**findSequenceOnDisk** — find one specific sequence
+
+.. code-block:: python
+
+    # Wildcard padding: accepts any number of digits
+    seq = FileSequence.findSequenceOnDisk('/renders/beauty.@.exr')
+
+    # Strict padding: only files that match the token width exactly
+    seq = FileSequence.findSequenceOnDisk('/renders/beauty.%04d.exr', strictPadding=True)
+
+    # Preserve the original padding token in the result
+    seq = FileSequence.findSequenceOnDisk('/renders/beauty.%02d.exr',
+                                          strictPadding=True,
+                                          preserve_padding=True)
+
+**findSequencesInList** — build sequences from an existing file list in memory
+
+This is useful when you already have a list of paths (e.g. from an asset database) and do not
+want a directory scan:
+
+.. code-block:: python
+
+    paths = [
+        '/renders/beauty.0001.exr',
+        '/renders/beauty.0002.exr',
+        '/renders/beauty.0003.exr',
+        '/renders/hero.0001.exr',
+    ]
+    seqs = FileSequence.findSequencesInList(paths)
+    # Returns two FileSequence objects: beauty.1-3#.exr and hero.0001#.exr
+
+Normally each path is parsed through the grammar to identify its dirname, basename, extension,
+and frame number.  When you already know that all paths share the same structure, pass a
+``using`` template to skip that per-path parsing.  The template's dirname, basename, and
+extension are used to compute character offsets, so the frame number is extracted by a plain
+string slice rather than a full parse.  This can be significantly faster when the list is large:
+
+.. code-block:: python
+
+    # Without template: every path is parsed individually
+    seqs = FileSequence.findSequencesInList(paths)
+
+    # With template: frame extracted via string slicing — no per-path grammar parse
+    template = FileSequence('/renders/beauty.#.exr')
+    seqs = FileSequence.findSequencesInList(paths, using=template)
+
+The template is also useful when the filename has an ambiguous structure — for example, a
+basename that contains digits — and you want to pin exactly which numeric run is the frame
+number:
+
+.. code-block:: python
+
+    paths = [
+        '/renders/shot_101_beauty.0001.exr',
+        '/renders/shot_101_beauty.0002.exr',
+        '/renders/shot_101_beauty.0003.exr',
+    ]
+    # Without template, the '101' in the name could confuse sequence grouping.
+    # The template makes the intent unambiguous:
+    template = FileSequence('/renders/shot_101_beauty.#.exr')
+    seqs = FileSequence.findSequencesInList(paths, using=template)
+    # [<FileSequence: '/renders/shot_101_beauty.1-3#.exr'>]
+
+Customizing with Subclasses
+---------------------------
+
+Both :class:`~fileseq.FileSequence` and :class:`~fileseq.FilePathSequence` inherit from the
+abstract base :class:`~fileseq.filesequence.BaseFileSequence`.  You can subclass either to add
+custom behaviour by overriding one or both hooks described below.
+
+**_preprocess_sequence — translate custom syntax before parsing**
+
+Override this method to accept sequence strings that use a non-standard notation.  The hook
+receives the raw input string and must return a string in the grammar that fileseq understands.
+
+VRay uses a ``<frameNN>`` token (e.g. ``<frame04>``) to express padding width.  This token is
+not part of the fileseq grammar, but it maps cleanly to printf-style padding, so
+``_preprocess_sequence`` is the right place to translate it:
+
+.. code-block:: python
+
+    import re
+    import fileseq
+
+    class VRayFileSequence(fileseq.FileSequence):
+        """Translate VRay ``<frameNN>`` padding tokens to printf-style before parsing."""
+
+        _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+
+        def _preprocess_sequence(self, sequence: str) -> str:
+            def replace(m):
+                width = int(m.group(1))
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._VRAY_PAD_RE.sub(replace, sequence)
+
+    # With a frame range
+    seq = VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+    seq.padding()     # '%04d'
+    seq.frameRange()  # '0001-0100'
+    seq.frame(42)     # '/render/beauty.0042.exr'
+
+    # Pattern-only (no range embedded in the string)
+    seq = VRayFileSequence('/render/beauty.<frame04>.exr')
+    seq.padding()     # '%04d'
+    seq.frameRange()  # ''
+
+    # Subframe variant — two tokens, one for frames and one for the sub-second part
+    seq = VRayFileSequence(
+        '/render/beauty.1-5<frame04>.10-20<frame04>.exr',
+        allow_subframes=True,
+    )
+    seq.frame(1)  # '/render/beauty.0001.0000.exr'
+
+**_postprocess_sequence — restore custom syntax on output**
+
+This is the complement to ``_preprocess_sequence``.  It is called by :meth:`~fileseq.FileSequence.__str__`
+and :meth:`~fileseq.FileSequence.format` on the fully assembled sequence string just before it
+is returned, giving subclasses the opportunity to translate internal grammar tokens back to the
+original custom format.
+
+Continuing the VRay example, adding ``_postprocess_sequence`` makes the class fully
+round-trippable — the ``<frameNN>`` token survives both directions:
+
+.. code-block:: python
+
+    import re
+    import fileseq
+
+    class VRayFileSequence(fileseq.FileSequence):
+        """Translate VRay ``<frameNN>`` padding tokens in both directions."""
+
+        _VRAY_PAD_RE  = re.compile(r'<frame(\d+)>')
+        _PRINTF_PAD_RE = re.compile(r'%0?(\d+)d')
+
+        def _preprocess_sequence(self, sequence: str) -> str:
+            def replace(m):
+                width = int(m.group(1))
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._VRAY_PAD_RE.sub(replace, sequence)
+
+        def _postprocess_sequence(self, sequence: str) -> str:
+            def replace(m):
+                return '<frame{:02d}>'.format(int(m.group(1)))
+            return self._PRINTF_PAD_RE.sub(replace, sequence)
+
+    seq = VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+    str(seq)    # '/render/beauty.1-100<frame04>.exr'
+    seq.frame(42)  # '/render/beauty.0042.exr'  (frame paths are unaffected)
+
+    # format() also passes through _postprocess_sequence
+    seq.format('{dirname}{basename}{range}{padding}{extension}')
+    # '/render/beauty.0001-0100<frame04>.exr'
+
+Two things worth noting:
+
+- ``_postprocess_sequence`` is **not** called by :meth:`~fileseq.FileSequence.frame` or
+  iteration — only by the methods that produce a sequence pattern string.  Individual frame
+  paths use the internal grammar padding (``%04d``) to resolve frame numbers correctly, so
+  they are unaffected.
+- :meth:`~fileseq.FileSequence.__str__` omits the padding token entirely when the sequence has
+  no frame range.  For a pattern-only sequence, use :meth:`~fileseq.FileSequence.format` with
+  an explicit ``{padding}`` field to get the round-tripped token back:
+
+  .. code-block:: python
+
+      seq = VRayFileSequence('/render/beauty.<frame04>.exr')
+      str(seq)  # '/render/beauty..exr'  — padding omitted by str()
+      seq.format('{dirname}{basename}{padding}{extension}')
+      # '/render/beauty.<frame04>.exr'
+
+**_create_path — control the type returned for each frame path**
+
+Override this method to return a custom path type instead of a plain string.  The method
+receives a fully-resolved path string and must return whatever object your code needs.
+
+.. code-block:: python
+
+    from pathlib import Path
+    from fileseq import FileSequence
+
+    class S3FileSequence(FileSequence):
+        """Return S3-prefixed paths instead of local paths."""
+
+        BUCKET = 's3://my-studio-bucket'
+
+        def _create_path(self, path_str: str) -> str:
+            # Strip the leading slash so the URL is well-formed
+            return f'{self.BUCKET}/{path_str.lstrip("/")}'
+
+    seq = S3FileSequence('/renders/beauty.1-3#.exr')
+    seq.frame(1)  # 's3://my-studio-bucket/renders/beauty.0001.exr'
+    list(seq)
+    # ['s3://my-studio-bucket/renders/beauty.0001.exr',
+    #  's3://my-studio-bucket/renders/beauty.0002.exr',
+    #  's3://my-studio-bucket/renders/beauty.0003.exr']
+
+Both hooks may be combined in a single subclass.

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -115,6 +115,7 @@ class BaseFileSequence(typing.Generic[T]):
             skip_parse: If True, skip parsing and use existing component values
         """
         sequence = utils.asString(sequence)
+        sequence = self._preprocess_sequence(sequence)
 
         # Detect and store the path separator from input
         self._sep = utils._getPathSep(sequence)
@@ -217,6 +218,22 @@ class BaseFileSequence(typing.Generic[T]):
             T: The path in the appropriate type for this sequence
         """
         raise NotImplementedError("Subclasses must implement _create_path")
+
+    def _preprocess_sequence(self, sequence: str) -> str:
+        """Override to translate custom sequence syntax before parsing.
+
+        Called with the raw sequence string before any parsing takes place.
+        The returned string must be valid syntax recognized by the fileseq
+        grammar, including frame ranges (e.g. ``1-100``, ``1,2,3``) and
+        padding formats (e.g. ``#``, ``@``, ``%04d``, ``$F4``, ``<UDIM>``).
+
+        Args:
+            sequence (str): the raw input sequence string
+
+        Returns:
+            str: the (possibly modified) sequence string
+        """
+        return sequence
 
     @property
     def _sep(self) -> str:

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -1172,22 +1172,36 @@ class BaseFileSequence(typing.Generic[T]):
     def findSequencesInList(cls,
                             paths: typing.Iterable[str | pathlib.Path],
                             pad_style: constants._PadStyle = PAD_STYLE_DEFAULT,
-                            allow_subframes: bool = False) -> list[Self]:
+                            allow_subframes: bool = False,
+                            klass: type[BaseFileSequence] | None = None) -> list[Self]:
         """
         Returns the list of discrete sequences within paths.  This does not try
         to determine if the files actually exist on disk, it assumes you
         already know that.
 
+        The simplest way to get results of a custom subclass is to call this
+        method on the subclass directly::
+
+            VRayFileSequence.findSequencesInList(paths)
+
+        The ``klass`` argument is an alternative for callers that need to
+        specify the result class without changing the call site::
+
+            FileSequence.findSequencesInList(paths, klass=VRayFileSequence)
+
         Args:
             paths (list[str | pathlib.Path]): a list of paths
             pad_style (`PAD_STYLE_DEFAULT` or `PAD_STYLE_HASH1` or `PAD_STYLE_HASH4`): padding style
             allow_subframes (bool): if True, handle subframe filenames
+            klass (type, optional): :class:`FileSequence` subclass to use when
+                constructing results.  Defaults to the calling class.
 
         Returns:
             list:
         """
+        klass = klass or cls
         return list(
-            cls.yield_sequences_in_list(paths, pad_style=pad_style, allow_subframes=allow_subframes)
+            klass.yield_sequences_in_list(paths, pad_style=pad_style, allow_subframes=allow_subframes)
         )
 
     @classmethod
@@ -1197,7 +1211,8 @@ class BaseFileSequence(typing.Generic[T]):
             include_hidden: bool = False,
             strictPadding: bool = False,
             pad_style: constants._PadStyle = PAD_STYLE_DEFAULT,
-            allow_subframes: bool = False) -> list[Self]:
+            allow_subframes: bool = False,
+            klass: type[BaseFileSequence] | None = None) -> list[Self]:
         """
         Yield the sequences found in the given directory.
 
@@ -1221,16 +1236,34 @@ class BaseFileSequence(typing.Generic[T]):
             FileSequence.findSequencesOnDisk('/path/to/files/image_stereo_{left,right}.#.jpg')
             FileSequence.findSequencesOnDisk('/path/to/files/imag?_*_{left,right}.@@@.jpg', strictPadding=True)
 
+        The simplest way to get results of a custom subclass is to call this
+        method on the subclass directly::
+
+            VRayFileSequence.findSequencesOnDisk('/path/to/files')
+
+        The ``klass`` argument is an alternative for callers that need to
+        specify the result class without changing the call site::
+
+            FileSequence.findSequencesOnDisk('/path/to/files', klass=VRayFileSequence)
+
         Args:
             pattern (str): directory to scan, or pattern to filter in directory
             include_hidden (bool): if true, show .hidden files as well
             strictPadding (bool): if True, ignore files with padding length different from pattern
             pad_style (`PAD_STYLE_DEFAULT` or `PAD_STYLE_HASH1` or `PAD_STYLE_HASH4`): padding style
             allow_subframes (bool): if True, handle subframe filenames
+            klass (type, optional): :class:`FileSequence` subclass to use when
+                constructing results.  Defaults to the calling class.  Pass a
+                subclass that overrides :meth:`_preprocess_sequence` to accept
+                custom padding tokens in ``pattern``, and/or
+                :meth:`_postprocess_sequence` to restore them in the returned
+                sequence strings.
 
         Returns:
             list:
         """
+        klass = klass or cls
+
         # reserve some functions we're going to need quick access to
         _not_hidden = lambda f: not f.startswith('.')
         _match_pattern = None
@@ -1250,12 +1283,12 @@ class BaseFileSequence(typing.Generic[T]):
 
             # Start building a regex for filtering files
             try:
-                seq = cls(filepat, pad_style=pad_style, allow_subframes=allow_subframes)
+                seq = klass(filepat, pad_style=pad_style, allow_subframes=allow_subframes)
             except ParseException:
                 # Invalid pattern (e.g., mixed padding like #@) - return empty list
                 return []
             patt = r'\A'
-            patt += cls._globCharsToRegex(seq.basename())
+            patt += klass._globCharsToRegex(seq.basename())
             if seq.padding():
                 patt += '('
                 if seq.framePadding():
@@ -1264,7 +1297,7 @@ class BaseFileSequence(typing.Generic[T]):
                         patt += r'\.\d+'
                 patt += ')'
             if seq.extension():
-                patt += cls._globCharsToRegex(seq.extension())
+                patt += klass._globCharsToRegex(seq.extension())
 
             # Convert braces groups into regex capture groups
             matches = re.finditer(r'{(.*?)(?:,(.*?))*}', patt)
@@ -1282,7 +1315,7 @@ class BaseFileSequence(typing.Generic[T]):
             if seq.padding() and strictPadding:
                 get_frame = lambda f: _match_pattern(f).group(1)  # type: ignore
                 _filter_padding = functools.partial(
-                    cls._filterByPaddingNum,
+                    klass._filterByPaddingNum,
                     zfill=seq.zfill(),
                     decimal_places=seq.decimalPlaces(),
                     get_frame=get_frame
@@ -1317,12 +1350,12 @@ class BaseFileSequence(typing.Generic[T]):
         files = [_join(dirpath, f) for f in files]
 
         seqs = list(
-            cls.yield_sequences_in_list(files, pad_style=pad_style, allow_subframes=allow_subframes)
+            klass.yield_sequences_in_list(files, pad_style=pad_style, allow_subframes=allow_subframes)
         )
 
         if _filter_padding and seq:
-            frame_pad = cls.conformPadding(seq.framePadding(), pad_style=pad_style)
-            subframe_pad = cls.conformPadding(seq.subframePadding(), pad_style=pad_style)
+            frame_pad = klass.conformPadding(seq.framePadding(), pad_style=pad_style)
+            subframe_pad = klass.conformPadding(seq.subframePadding(), pad_style=pad_style)
             # strict padding should preserve the original padding
             # characters in the found sequences.
             for s in seqs:
@@ -1339,7 +1372,8 @@ class BaseFileSequence(typing.Generic[T]):
             pad_style: constants._PadStyle = PAD_STYLE_DEFAULT,
             allow_subframes: bool = False,
             force_case_sensitive: bool = True,
-            preserve_padding: bool = False) -> Self:
+            preserve_padding: bool = False,
+            klass: type[BaseFileSequence] | None = None) -> Self:
         """
         Search for a specific sequence on disk.
 
@@ -1373,6 +1407,22 @@ class BaseFileSequence(typing.Generic[T]):
 
                 ``FileSequence.findSequenceOnDisk("seq/bar%03d.exr", strictPadding=True, preserve_padding=True)``
 
+        The simplest way to get results of a custom subclass — including using a
+        custom padding token in the pattern — is to call this method on the
+        subclass directly::
+
+            VRayFileSequence.findSequenceOnDisk("seq/bar<frame04>.exr",
+                                                strictPadding=True,
+                                                preserve_padding=True)
+
+        The ``klass`` argument is an alternative for callers that need to
+        specify the result class without changing the call site::
+
+            FileSequence.findSequenceOnDisk("seq/bar<frame04>.exr",
+                                            strictPadding=True,
+                                            preserve_padding=True,
+                                            klass=VRayFileSequence)
+
         Note:
             Unlike `findSequencesOnDisk`, general wildcard characters ("*", "?") are not
             supported and result in undefined behavior. Only the frame component of the paths may
@@ -1386,6 +1436,12 @@ class BaseFileSequence(typing.Generic[T]):
             force_case_sensitive (bool): force posix-style case-sensitive matching on Windows filesystems
             preserve_padding (bool): if True, preserve pattern-provided padding characters in returned
                 sequence, if the padding length matches. Default: conform padding to "#@" style.
+            klass (type, optional): :class:`FileSequence` subclass to use when
+                constructing results.  Defaults to the calling class.  Pass a
+                subclass that overrides :meth:`_preprocess_sequence` to accept
+                custom padding tokens in ``pattern``, and/or
+                :meth:`_postprocess_sequence` to restore them in the returned
+                sequence string.
 
         Returns:
             Self: A single matching file sequence existing on disk
@@ -1393,6 +1449,8 @@ class BaseFileSequence(typing.Generic[T]):
         Raises:
             :class:`.FileSeqException`: if no sequence is found on disk
         """
+        klass = klass or cls
+
         # Pre-process pattern: convert double-frame patterns like "baz.0000.0000.exr"
         # to padding syntax "baz.#.#.exr" when allow_subframes=True
         original_pattern = pattern
@@ -1404,18 +1462,18 @@ class BaseFileSequence(typing.Generic[T]):
             if regex_match:
                 prefix, frame1, frame2, ext = regex_match.groups()
                 # Convert to padding syntax: replace digits with padding chars
-                pad1 = cls.getPaddingChars(len(frame1) - 1, pad_style=pad_style)  # -1 for dot
-                pad2 = cls.getPaddingChars(len(frame2) - 1, pad_style=pad_style)
+                pad1 = klass.getPaddingChars(len(frame1) - 1, pad_style=pad_style)  # -1 for dot
+                pad2 = klass.getPaddingChars(len(frame2) - 1, pad_style=pad_style)
                 pattern = f"{prefix}.{pad1}.{pad2}{ext}"
 
         try:
-            seq = cls(pattern, allow_subframes=allow_subframes, pad_style=pad_style)
+            seq = klass(pattern, allow_subframes=allow_subframes, pad_style=pad_style)
         except ParseException as e:
             # Handle mixed padding (like #@) when strictPadding=False
-            if not strictPadding and cls._has_mixed_padding(pattern):
+            if not strictPadding and klass._has_mixed_padding(pattern):
                 # Normalize mixed padding to single character for non-strict matching
-                normalized = cls._normalize_mixed_padding(pattern)
-                seq = cls(normalized, allow_subframes=allow_subframes, pad_style=pad_style)
+                normalized = klass._normalize_mixed_padding(pattern)
+                seq = klass(normalized, allow_subframes=allow_subframes, pad_style=pad_style)
             else:
                 raise
 
@@ -1446,7 +1504,7 @@ class BaseFileSequence(typing.Generic[T]):
                 case_match = re.compile(fnmatch.translate(patt)).match
                 globbed = (p for p in globbed if case_match(p))
 
-        pad_filter_ctx = cls._FilterByPaddingNum()
+        pad_filter_ctx = klass._FilterByPaddingNum()
 
         if pad:
             patt = r'\A'
@@ -1468,8 +1526,8 @@ class BaseFileSequence(typing.Generic[T]):
                     get_frame=get_frame
                 )
                 if not preserve_padding:
-                    frame_pad = cls.conformPadding(frame_pad, pad_style=pad_style)
-                    subframe_pad = cls.conformPadding(subframe_pad, pad_style=pad_style)
+                    frame_pad = klass.conformPadding(frame_pad, pad_style=pad_style)
+                    subframe_pad = klass.conformPadding(subframe_pad, pad_style=pad_style)
             else:
                 globbed = pad_filter_ctx(
                     globbed,
@@ -1480,7 +1538,7 @@ class BaseFileSequence(typing.Generic[T]):
 
         sequences = []
         allow_subframes = bool(seq.decimalPlaces())
-        for match in cls.yield_sequences_in_list(
+        for match in klass.yield_sequences_in_list(
                 globbed, using=seq, pad_style=pad_style, allow_subframes=allow_subframes
         ):
             if match.basename() == basename and match.extension() == ext:

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -1173,7 +1173,7 @@ class BaseFileSequence(typing.Generic[T]):
                             paths: typing.Iterable[str | pathlib.Path],
                             pad_style: constants._PadStyle = PAD_STYLE_DEFAULT,
                             allow_subframes: bool = False,
-                            klass: type[BaseFileSequence] | None = None) -> list[Self]:
+                            klass: type[Self] | None = None) -> list[Self]:
         """
         Returns the list of discrete sequences within paths.  This does not try
         to determine if the files actually exist on disk, it assumes you
@@ -1212,7 +1212,7 @@ class BaseFileSequence(typing.Generic[T]):
             strictPadding: bool = False,
             pad_style: constants._PadStyle = PAD_STYLE_DEFAULT,
             allow_subframes: bool = False,
-            klass: type[BaseFileSequence] | None = None) -> list[Self]:
+            klass: type[Self] | None = None) -> list[Self]:
         """
         Yield the sequences found in the given directory.
 
@@ -1373,7 +1373,7 @@ class BaseFileSequence(typing.Generic[T]):
             allow_subframes: bool = False,
             force_case_sensitive: bool = True,
             preserve_padding: bool = False,
-            klass: type[BaseFileSequence] | None = None) -> Self:
+            klass: type[Self] | None = None) -> Self:
         """
         Search for a specific sequence on disk.
 

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -235,6 +235,25 @@ class BaseFileSequence(typing.Generic[T]):
         """
         return sequence
 
+    def _postprocess_sequence(self, sequence: str) -> str:
+        """Override to translate the assembled sequence string back to custom syntax.
+
+        This is the complement to :meth:`_preprocess_sequence`.  It is called
+        with the fully assembled sequence string just before it is returned by
+        :meth:`__str__` and :meth:`format`, giving subclasses the opportunity
+        to restore any custom padding tokens or other syntax that was translated
+        during preprocessing.
+
+        The default implementation is a no-op.
+
+        Args:
+            sequence (str): the assembled sequence string in fileseq grammar
+
+        Returns:
+            str: the (possibly modified) sequence string
+        """
+        return sequence
+
     @property
     def _sep(self) -> str:
         """Path separator, defaults to os.sep if not explicitly set."""
@@ -298,14 +317,14 @@ class BaseFileSequence(typing.Generic[T]):
         # and user never asked for it in template
         inverted = (self.invertedFrameRange() or "") if "{inverted}" in template else ""
 
-        return template.format(
+        return self._postprocess_sequence(template.format(
             basename=self.basename(),
             extension=self.extension(), start=self.start(),
             end=self.end(), length=len(self),
             padding=self.padding(),
             range=self.frameRange() or "",
             inverted=inverted,
-            dirname=self.dirname())
+            dirname=self.dirname()))
 
     def split(self) -> list[BaseFileSequence[T]]:
         """
@@ -907,7 +926,7 @@ class BaseFileSequence(typing.Generic[T]):
         if self._has_negative_zero and frameSet_str == '0':
             frameSet_str = '-0'
         cmpts.frameSet = frameSet_str
-        return "".join(dataclasses.astuple(cmpts))
+        return self._postprocess_sequence("".join(dataclasses.astuple(cmpts)))
 
     def __repr__(self) -> str:
         try:

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2838,5 +2838,78 @@ class TestPostprocessSequence(TestBase):
         self.assertEqual('/path/file.1-5<frame04>.10-20<frame04>.exr', str(seq))
 
 
+class TestFindWithKlass(TestBase):
+    """Test the klass argument on filesystem find methods."""
+
+    class VRayFileSequence(FileSequence):
+        """Translates VRay <frameNN> padding tokens in both directions."""
+        _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+        _PRINTF_PAD_RE = re.compile(r'%0?(\d+)d')
+
+        def _preprocess_sequence(self, sequence):
+            def replace(m):
+                width = int(m.group(1))
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._VRAY_PAD_RE.sub(replace, sequence)
+
+        def _postprocess_sequence(self, sequence):
+            def replace(m):
+                return '<frame{:02d}>'.format(int(m.group(1)))
+            return self._PRINTF_PAD_RE.sub(replace, sequence)
+
+    # --- findSequencesOnDisk ---
+
+    def testFindSequencesOnDiskKlassInstances(self):
+        """Results are instances of klass, not the calling class."""
+        seqs = FileSequence.findSequencesOnDisk('seq', klass=self.VRayFileSequence)
+        self.assertGreater(len(seqs), 0)
+        for seq in seqs:
+            self.assertIsInstance(seq, self.VRayFileSequence)
+
+    def testFindSequencesOnDiskKlassAcceptsCustomPattern(self):
+        """klass._preprocess_sequence translates a VRay token pattern before scanning.
+
+        Without klass the VRay token is an unrecognized padding character and the
+        call silently returns an empty list.  With klass it succeeds.
+        """
+        seqs = FileSequence.findSequencesOnDisk(
+            'seq/foo.<frame04>.exr',
+            klass=self.VRayFileSequence,
+        )
+        self.assertEqual(1, len(seqs))
+        self.assertIsInstance(seqs[0], self.VRayFileSequence)
+
+    def testFindSequencesInListKlassInstances(self):
+        """Results are instances of klass, not the calling class."""
+        paths = [
+            'seq/foo.0001.exr',
+            'seq/foo.0002.exr',
+            'seq/foo.0003.exr',
+        ]
+        seqs = FileSequence.findSequencesInList(paths, klass=self.VRayFileSequence)
+        self.assertEqual(1, len(seqs))
+        self.assertIsInstance(seqs[0], self.VRayFileSequence)
+
+    # --- findSequenceOnDisk ---
+
+    def testFindSequenceOnDiskKlassInstances(self):
+        """Result is an instance of klass."""
+        seq = FileSequence.findSequenceOnDisk('seq/foo.#.exr', klass=self.VRayFileSequence)
+        self.assertIsInstance(seq, self.VRayFileSequence)
+
+    def testFindSequenceOnDiskKlassVRayPattern(self):
+        """_preprocess_sequence translates the VRay pattern before scanning,
+        and _postprocess_sequence restores it in str() output."""
+        seq = FileSequence.findSequenceOnDisk(
+            'seq/foo.<frame04>.exr',
+            strictPadding=True,
+            preserve_padding=True,
+            klass=self.VRayFileSequence,
+        )
+        self.assertIsInstance(seq, self.VRayFileSequence)
+        self.assertEqual('%04d', seq.padding())
+        self.assertEqual('seq/foo.1-5<frame04>.exr', str(seq))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=1)

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2770,5 +2770,73 @@ class TestPreprocessSequence(TestBase):
         self.assertEqual('/path/file.0100.exr', seq.frame(100))
 
 
+class TestPostprocessSequence(TestBase):
+    """Test the _postprocess_sequence hook for restoring original string format."""
+
+    class VRayFileSequence(FileSequence):
+        """Translates VRay <frameNN> padding to printf on input and back on output."""
+        _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+        _PRINTF_PAD_RE = re.compile(r'%0?(\d+)d')
+
+        def _preprocess_sequence(self, sequence):
+            def replace(m):
+                width = int(m.group(1))
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._VRAY_PAD_RE.sub(replace, sequence)
+
+        def _postprocess_sequence(self, sequence):
+            def replace(m):
+                return '<frame{:02d}>'.format(int(m.group(1)))
+            return self._PRINTF_PAD_RE.sub(replace, sequence)
+
+    def testNoopDefault(self):
+        """Default _postprocess_sequence is a no-op."""
+        seq = FileSequence('/path/file.1-100#.exr')
+        self.assertEqual('/path/file.1-100#.exr', seq._postprocess_sequence('/path/file.1-100#.exr'))
+
+    def testStrPreservesOriginalPadding(self):
+        """str() round-trips back to the original VRay token."""
+        seq = self.VRayFileSequence('/path/file.1-100<frame04>.exr')
+        # str() uses the FrameSet's own range string (not zero-padded)
+        self.assertEqual('/path/file.1-100<frame04>.exr', str(seq))
+
+    def testFormatPreservesOriginalPadding(self):
+        """format() round-trips back to the original VRay token."""
+        seq = self.VRayFileSequence('/path/file.1-100<frame04>.exr')
+        # {range} in format() uses the zero-padded frameRange()
+        self.assertEqual(
+            '/path/file.0001-0100<frame04>.exr',
+            seq.format('{dirname}{basename}{range}{padding}{extension}'),
+        )
+
+    def testPatternOnlyPreservesOriginalPadding(self):
+        """format() on a pattern-only sequence restores the original token.
+
+        Note: str() omits padding for sequences with no frame range (by design),
+        so format() with an explicit {padding} field is needed for round-tripping.
+        """
+        seq = self.VRayFileSequence('/path/file.<frame04>.exr')
+        self.assertEqual(
+            '/path/file.<frame04>.exr',
+            seq.format('{dirname}{basename}{padding}{extension}'),
+        )
+
+    def testSplitPreservesOriginalPadding(self):
+        """Each piece from split() also round-trips through _postprocess_sequence."""
+        seq = self.VRayFileSequence('/path/file.1-5,10-20<frame04>.exr')
+        pieces = seq.split()
+        # split() rebuilds from zero-padded frameRange(), so that form is preserved
+        self.assertEqual('/path/file.0001-0005<frame04>.exr', str(pieces[0]))
+        self.assertEqual('/path/file.0010-0020<frame04>.exr', str(pieces[1]))
+
+    def testSubframesPreservesOriginalPadding(self):
+        """Subframe sequences round-trip through _postprocess_sequence."""
+        seq = self.VRayFileSequence(
+            '/path/file.1-5<frame04>.10-20<frame04>.exr',
+            allow_subframes=True,
+        )
+        self.assertEqual('/path/file.1-5<frame04>.10-20<frame04>.exr', str(seq))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=1)

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2691,5 +2691,84 @@ class TestPaddingFunctions(TestBase):
             self.assertEqual(test.has_padded, filter_ctx.has_padded_frames)
 
 
+class TestPreprocessSequence(TestBase):
+    """Test the _preprocess_sequence hook for custom padding format translation."""
+
+    class VRayFileSequence(FileSequence):
+        """Example subclass that translates VRay <frameNN> padding to printf syntax."""
+        _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+
+        def _preprocess_sequence(self, sequence):
+            def replace(m):
+                width = int(m.group(1))
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._VRAY_PAD_RE.sub(replace, sequence)
+
+    def testNoopDefault(self):
+        """Default implementation is a no-op."""
+        seq = FileSequence('/path/file.1-100#.exr')
+        self.assertEqual('/path/file.1-100#.exr', seq._preprocess_sequence('/path/file.1-100#.exr'))
+
+    def testPaddingBasic(self):
+        """VRay <frameNN> padding is translated to printf syntax."""
+        seq = self.VRayFileSequence('/path/file.1-100<frame04>.exr')
+        self.assertEqual('/path/file.', seq.dirname() + seq.basename())
+        self.assertEqual('.exr', seq.extension())
+        self.assertEqual('%04d', seq.padding())
+        self.assertEqual(4, seq.zfill())
+        self.assertEqual('0001-0100', seq.frameRange())
+        self.assertEqual('/path/file.0001.exr', seq.frame(1))
+        self.assertEqual('/path/file.0042.exr', seq.frame(42))
+
+    def testPaddingPatternOnly(self):
+        """VRay pattern-only (no frame range) is parsed correctly."""
+        seq = self.VRayFileSequence('/path/file.<frame04>.exr')
+        self.assertEqual('%04d', seq.padding())
+        self.assertEqual(4, seq.zfill())
+        self.assertEqual('', seq.frameRange())
+
+    def testPaddingSubframes(self):
+        """VRay <frameNN> with dual frame range (subframes) is translated correctly."""
+        seq = self.VRayFileSequence(
+            '/path/file.1-5<frame04>.10-20<frame04>.exr',
+            allow_subframes=True,
+        )
+        self.assertEqual('/path/file.', seq.dirname() + seq.basename())
+        self.assertEqual('.exr', seq.extension())
+        self.assertEqual('%04d', seq.framePadding())
+        self.assertEqual('%04d', seq.subframePadding())
+        self.assertEqual(4, seq.zfill())
+        self.assertEqual(4, seq.decimalPlaces())
+        self.assertEqual('/path/file.0001.0000.exr', seq.frame(1))
+        self.assertEqual('/path/file.0001.0010.exr', seq.frame(Decimal('1.0010')))
+
+    def testPaddingSubframesPatternOnly(self):
+        """VRay dual-padding pattern-only (no frame range) with subframes."""
+        seq = self.VRayFileSequence(
+            '/path/file.<frame04>.<frame04>.exr',
+            allow_subframes=True,
+        )
+        self.assertEqual('%04d', seq.framePadding())
+        self.assertEqual('%04d', seq.subframePadding())
+        self.assertEqual(4, seq.zfill())
+        self.assertEqual(4, seq.decimalPlaces())
+        self.assertEqual('', seq.frameRange())
+
+    def testCustomFrameRangeSyntax(self):
+        """Custom frame range delimiter '=' is translated to '-' before parsing."""
+
+        class EqualRangeFileSequence(FileSequence):
+            _EQUAL_RANGE_RE = re.compile(r'(\d+)=(\d+)')
+
+            def _preprocess_sequence(self, sequence):
+                return self._EQUAL_RANGE_RE.sub(r'\1-\2', sequence)
+
+        seq = EqualRangeFileSequence('/path/file.1=100#.exr')
+        self.assertEqual('0001-0100', seq.frameRange())
+        self.assertEqual(100, len(seq))
+        self.assertEqual('/path/file.0001.exr', seq.frame(1))
+        self.assertEqual('/path/file.0100.exr', seq.frame(100))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=1)


### PR DESCRIPTION
Adds a new `_preprocess_sequence(sequence: str)` hook to `BaseFileSequence`, allowing for custom `FileSequence` subclasses to handle custom sequence pattern logic, by transforming it before it is passed to the grammar parser.

Allows for custom types such as:

```python
class VRayFileSequence(FileSequence):
    """Example: /path/file.1-100<frame04>.ext """
    _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')

    def _preprocess_sequence(self, sequence):
        def replace(m):
            width = int(m.group(1))
            return '%0{}d'.format(width) if width > 0 else '%d'
        return self._VRAY_PAD_RE.sub(replace, sequence)


class EqualRangeFileSequence(FileSequence):
    """Example: /path/file.1=100#.ext """
    _EQUAL_RANGE_RE = re.compile(r'(\d+)=(\d+)')

    def _preprocess_sequence(self, sequence):
        return self._EQUAL_RANGE_RE.sub(r'\1-\2', sequence)
```