### PR TITLE
Refactor the subclass extension support for supporting custom patterns and paddings (refs #139)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -230,8 +230,8 @@ Three class methods locate sequences on disk.
 **Using a custom subclass with the find methods**
 
 All three find methods are classmethods, so the simplest way to get results of a
-custom subclass is to call the method directly on that subclass.  The
-``_preprocess_sequence`` and ``_postprocess_sequence`` hooks are picked up
+custom subclass is to call the method directly on that subclass.  All hooks
+(``_preprocess_sequence``, ``_resolve_padding``, ``getPaddingNum``) are picked up
 automatically:
 
 .. code-block:: python
@@ -320,8 +320,9 @@ Override this method to accept sequence strings that use a non-standard notation
 receives the raw input string and must return a string in the grammar that fileseq understands.
 
 VRay uses a ``<frameNN>`` token (e.g. ``<frame04>``) to express padding width.  This token is
-not part of the fileseq grammar, but it maps cleanly to printf-style padding, so
-``_preprocess_sequence`` is the right place to translate it:
+not part of the fileseq grammar, but it maps cleanly to printf-style padding.  Using all three
+hooks together makes the subclass fully round-trippable — ``padding()`` returns the VRay token
+and individual frame paths are still correctly zero-padded:
 
 .. code-block:: python
 
@@ -329,25 +330,40 @@ not part of the fileseq grammar, but it maps cleanly to printf-style padding, so
     import fileseq
 
     class VRayFileSequence(fileseq.FileSequence):
-        """Translate VRay ``<frameNN>`` padding tokens to printf-style before parsing."""
+        """Translate VRay ``<frameNN>`` padding tokens natively."""
 
         _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
 
         def _preprocess_sequence(self, sequence: str) -> str:
+            """Translate ``<frameNN>`` → ``%0Nd`` so the grammar accepts it."""
             def replace(m):
                 width = int(m.group(1))
                 return '%0{}d'.format(width) if width > 0 else '%d'
             return self._VRAY_PAD_RE.sub(replace, sequence)
 
+        def _resolve_padding(self, parsed_pad: str, zfill: int, pad_style) -> str:
+            """Translate the parsed printf form back to the canonical VRay token."""
+            if zfill > 0:
+                return '<frame{:02d}>'.format(zfill)
+            return parsed_pad
+
+        @classmethod
+        def getPaddingNum(cls, chars: str, **kwargs) -> int:
+            """Recognise ``<frameNN>`` tokens in addition to the built-in formats."""
+            m = cls._VRAY_PAD_RE.match(chars)
+            if m:
+                return int(m.group(1))
+            return super().getPaddingNum(chars, **kwargs)
+
     # With a frame range
     seq = VRayFileSequence('/render/beauty.1-100<frame04>.exr')
-    seq.padding()     # '%04d'
-    seq.frameRange()  # '0001-0100'
+    seq.padding()     # '<frame04>'
+    str(seq)          # '/render/beauty.1-100<frame04>.exr'
     seq.frame(42)     # '/render/beauty.0042.exr'
 
     # Pattern-only (no range embedded in the string)
     seq = VRayFileSequence('/render/beauty.<frame04>.exr')
-    seq.padding()     # '%04d'
+    seq.padding()     # '<frame04>'
     seq.frameRange()  # ''
 
     # Subframe variant — two tokens, one for frames and one for the sub-second part
@@ -357,62 +373,80 @@ not part of the fileseq grammar, but it maps cleanly to printf-style padding, so
     )
     seq.frame(1)  # '/render/beauty.0001.0000.exr'
 
+**Calling setPadding on a custom-format subclass**
+
+Passing a custom token to ``setPadding`` (e.g. ``seq.setPadding('<frame02>')``) works correctly
+as long as ``getPaddingNum`` is overridden to recognise that token — the zfill is updated and
+``padding()`` returns the new token.
+
+Passing a built-in token (e.g. ``seq.setPadding('%04d')``) stores it as-is.  The setter does
+not call ``_resolve_padding``, so the value is not converted to the custom format automatically.
+
+**_resolve_padding — canonicalise the internal padding representation**
+
+Override this method to store a custom token as the canonical padding form.  It is called
+immediately after ``_zfill`` is computed in ``_init_impl``, before anything is persisted, so
+the value it returns becomes what ``padding()``, ``framePadding()``, and ``str()`` all see.
+
+The default implementation is a no-op — it returns ``parsed_pad`` unchanged, which preserves
+existing behaviour for all built-in formats.
+
+When to use it: any time ``padding()`` should return a custom token rather than the
+grammar-normalised form (e.g. ``%04d``).  The two hooks are always used together:
+``_preprocess_sequence`` translates the input so the grammar accepts it, and
+``_resolve_padding`` translates the result back to the custom canonical form before storage.
+Override ``getPaddingNum`` as well so that ``setPadding`` with a custom token is handled
+correctly.
+
+See the complete three-override example in the ``_preprocess_sequence`` section above.
+
 **_postprocess_sequence — restore custom syntax on output**
 
 This is the complement to ``_preprocess_sequence``.  It is called by :meth:`~fileseq.FileSequence.__str__`
 and :meth:`~fileseq.FileSequence.format` on the fully assembled sequence string just before it
-is returned, giving subclasses the opportunity to translate internal grammar tokens back to the
-original custom format.
-
-Continuing the VRay example, adding ``_postprocess_sequence`` makes the class fully
-round-trippable — the ``<frameNN>`` token survives both directions:
+is returned, giving subclasses the opportunity to restore syntax that is not the padding token
+itself — for example, a custom frame range delimiter.
 
 .. code-block:: python
 
     import re
     import fileseq
 
-    class VRayFileSequence(fileseq.FileSequence):
-        """Translate VRay ``<frameNN>`` padding tokens in both directions."""
+    class EqualRangeFileSequence(fileseq.FileSequence):
+        """Accept ``1=100`` range syntax in addition to the standard ``1-100``."""
 
-        _VRAY_PAD_RE  = re.compile(r'<frame(\d+)>')
-        _PRINTF_PAD_RE = re.compile(r'%0?(\d+)d')
+        _EQUAL_RE = re.compile(r'(\d+)=(\d+)')
 
         def _preprocess_sequence(self, sequence: str) -> str:
-            def replace(m):
-                width = int(m.group(1))
-                return '%0{}d'.format(width) if width > 0 else '%d'
-            return self._VRAY_PAD_RE.sub(replace, sequence)
+            return self._EQUAL_RE.sub(r'\1-\2', sequence)
 
         def _postprocess_sequence(self, sequence: str) -> str:
-            def replace(m):
-                return '<frame{:02d}>'.format(int(m.group(1)))
-            return self._PRINTF_PAD_RE.sub(replace, sequence)
+            # FrameSet always emits '1-100'; restore the custom delimiter on output.
+            return sequence.replace('-', '=', 1)
 
-    seq = VRayFileSequence('/render/beauty.1-100<frame04>.exr')
-    str(seq)    # '/render/beauty.1-100<frame04>.exr'
-    seq.frame(42)  # '/render/beauty.0042.exr'  (frame paths are unaffected)
+    seq = EqualRangeFileSequence('/render/beauty.1=100#.exr')
+    str(seq)       # '/render/beauty.1=100#.exr'
+    seq.frame(42)  # '/render/beauty.0042.exr'
 
-    # format() also passes through _postprocess_sequence
-    seq.format('{dirname}{basename}{range}{padding}{extension}')
-    # '/render/beauty.0001-0100<frame04>.exr'
+.. note::
 
-Two things worth noting:
+   ``_postprocess_sequence`` can also be used to restore a custom padding token on output,
+   but ``_resolve_padding`` is the preferred approach for that — it stores the token as the
+   canonical form so that ``padding()`` and ``str()`` return it directly.
+   ``_postprocess_sequence`` is best reserved for transforming parts of the string that are
+   not the padding token (such as the frame range delimiter in the example above).
 
-- ``_postprocess_sequence`` is **not** called by :meth:`~fileseq.FileSequence.frame` or
-  iteration — only by the methods that produce a sequence pattern string.  Individual frame
-  paths use the internal grammar padding (``%04d``) to resolve frame numbers correctly, so
-  they are unaffected.
-- :meth:`~fileseq.FileSequence.__str__` omits the padding token entirely when the sequence has
-  no frame range.  For a pattern-only sequence, use :meth:`~fileseq.FileSequence.format` with
-  an explicit ``{padding}`` field to get the round-tripped token back:
+**Scope of _postprocess_sequence**
 
-  .. code-block:: python
+``_postprocess_sequence`` is only called by methods that produce a sequence pattern string
+(:meth:`~fileseq.FileSequence.__str__` and :meth:`~fileseq.FileSequence.format`).
+It is **not** called when resolving individual frame paths via
+:meth:`~fileseq.FileSequence.frame` or iteration — those use the internally stored padding
+directly, so frame paths are always correct regardless of what ``_postprocess_sequence`` does.
 
-      seq = VRayFileSequence('/render/beauty.<frame04>.exr')
-      str(seq)  # '/render/beauty..exr'  — padding omitted by str()
-      seq.format('{dirname}{basename}{padding}{extension}')
-      # '/render/beauty.<frame04>.exr'
+When the sequence has no frame range, :meth:`~fileseq.FileSequence.__str__` omits the padding
+token entirely.  Use :meth:`~fileseq.FileSequence.format` with an explicit ``{padding}`` field
+if you need the padding token in the output for a pattern-only sequence.
 
 **_create_path — control the type returned for each frame path**
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -312,7 +312,7 @@ Customizing with Subclasses
 
 Both :class:`~fileseq.FileSequence` and :class:`~fileseq.FilePathSequence` inherit from the
 abstract base :class:`~fileseq.filesequence.BaseFileSequence`.  You can subclass either to add
-custom behaviour by overriding one or both hooks described below.
+custom behavior by overriding one or both hooks described below.
 
 **_preprocess_sequence — translate custom syntax before parsing**
 
@@ -333,17 +333,24 @@ and individual frame paths are still correctly zero-padded:
         """Translate VRay ``<frameNN>`` padding tokens natively."""
 
         _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+        _used_custom_padding = False
 
         def _preprocess_sequence(self, sequence: str) -> str:
             """Translate ``<frameNN>`` → ``%0Nd`` so the grammar accepts it."""
             def replace(m):
                 width = int(m.group(1))
+                self._used_custom_padding = True
                 return '%0{}d'.format(width) if width > 0 else '%d'
             return self._VRAY_PAD_RE.sub(replace, sequence)
 
         def _resolve_padding(self, parsed_pad: str, zfill: int, pad_style) -> str:
-            """Translate the parsed printf form back to the canonical VRay token."""
-            if zfill > 0:
+            """Translate the parsed printf form back to the canonical VRay token.
+
+            Only do this if preprocessing actually saw and translated a
+            ``<frameNN>`` token. A built-in token that happens to imply the
+            same width (e.g. ``#``) must not be reinterpreted as VRay's.
+            """
+            if zfill > 0 and self._used_custom_padding:
                 return '<frame{:02d}>'.format(zfill)
             return parsed_pad
 
@@ -376,29 +383,67 @@ and individual frame paths are still correctly zero-padded:
 **Calling setPadding on a custom-format subclass**
 
 Passing a custom token to ``setPadding`` (e.g. ``seq.setPadding('<frame02>')``) works correctly
-as long as ``getPaddingNum`` is overridden to recognise that token — the zfill is updated and
+as long as ``getPaddingNum`` is overridden to recognize that token — the zfill is updated and
 ``padding()`` returns the new token.
 
 Passing a built-in token (e.g. ``seq.setPadding('%04d')``) stores it as-is.  The setter does
 not call ``_resolve_padding``, so the value is not converted to the custom format automatically.
 
-**_resolve_padding — canonicalise the internal padding representation**
+**_resolve_padding — canonicalize the internal padding representation**
 
 Override this method to store a custom token as the canonical padding form.  It is called
 immediately after ``_zfill`` is computed in ``_init_impl``, before anything is persisted, so
 the value it returns becomes what ``padding()``, ``framePadding()``, and ``str()`` all see.
 
 The default implementation is a no-op — it returns ``parsed_pad`` unchanged, which preserves
-existing behaviour for all built-in formats.
+existing behavior for all built-in formats.
 
 When to use it: any time ``padding()`` should return a custom token rather than the
-grammar-normalised form (e.g. ``%04d``).  The two hooks are always used together:
+grammar-normalized form (e.g. ``%04d``).  The two hooks are always used together:
 ``_preprocess_sequence`` translates the input so the grammar accepts it, and
 ``_resolve_padding`` translates the result back to the custom canonical form before storage.
 Override ``getPaddingNum`` as well so that ``setPadding`` with a custom token is handled
 correctly.
 
 See the complete three-override example in the ``_preprocess_sequence`` section above.
+
+**parsePadding: detect a padding token in an arbitrary string**
+
+The hooks above all operate on a fully constructed sequence instance.  Sometimes you just need
+to answer "does this string contain a padding token at all" for a string that may not be a
+complete, valid sequence on its own, such as a single file path with no frame range.
+``parsePadding`` is a classmethod for exactly that:
+
+.. code-block:: python
+
+    FileSequence.parsePadding('/render/beauty.#.exr')     # '#'
+    FileSequence.parsePadding('/render/beauty.1001.exr')  # ''  (a resolved frame number, not a token)
+    FileSequence.parsePadding('/render/beauty.exr')       # ''
+
+The default implementation recognizes the built-in fileseq tokens.  Override it alongside
+``_preprocess_sequence`` to also recognize a custom token, falling back to the built-in behavior
+when no custom token is present:
+
+.. code-block:: python
+
+    class VRayFileSequence(fileseq.FileSequence):
+        # ... _preprocess_sequence, _resolve_padding, getPaddingNum as above ...
+
+        @classmethod
+        def parsePadding(cls, sequence: str) -> str:
+            padding = super().parsePadding(sequence)
+            if not padding:
+                m = cls._VRAY_PAD_RE.search(sequence)
+                if m:
+                    padding = m.group(0)
+            return padding
+
+    VRayFileSequence.parsePadding('/render/beauty.<frame04>.exr')  # '<frame04>'
+    VRayFileSequence.parsePadding('/render/beauty.#.exr')          # '#'
+    VRayFileSequence.parsePadding('/render/beauty.exr')            # ''
+
+    def has_padding(path: str) -> bool:
+        return bool(VRayFileSequence.parsePadding(path))
 
 **_postprocess_sequence — restore custom syntax on output**
 

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -199,6 +199,18 @@ class BaseFileSequence(typing.Generic[T]):
         self._zfill = self.getPaddingNum(self._frame_pad, pad_style=pad_style)
         self._decimal_places = self.getPaddingNum(self._subframe_pad, pad_style=pad_style)
 
+        # Allow subclasses to canonicalize the padding representation.
+        self._frame_pad = self._resolve_padding(self._frame_pad, self._zfill, pad_style)
+        if self._subframe_pad:
+            self._subframe_pad = self._resolve_padding(
+                self._subframe_pad, self._decimal_places, pad_style
+            )
+        # Keep _pad consistent with the (possibly updated) frame/subframe components.
+        if self._subframe_pad:
+            self._pad = '.'.join([self._frame_pad, self._subframe_pad])
+        else:
+            self._pad = self._frame_pad
+
         # Round subframes to match sequence
         if self._frameSet is not None and self._frameSet.hasSubFrames():
             self._frameSet = FrameSet([
@@ -234,6 +246,30 @@ class BaseFileSequence(typing.Generic[T]):
             str: the (possibly modified) sequence string
         """
         return sequence
+
+    def _resolve_padding(self, parsed_pad: str, zfill: int, pad_style) -> str:
+        """
+        Normalize the padding string after parsing.
+
+        Called immediately after ``_zfill`` is computed in :meth:`_init_impl`,
+        once for the frame padding and once for the subframe padding if present.
+        The default implementation returns *parsed_pad* unchanged, which
+        preserves existing behavior for all standard formats.
+
+        Override in a subclass to store a custom canonical representation.
+        For example, a VRay subclass would return ``'<frame04>'`` here
+        rather than letting ``'%04d'`` be stored as the internal padding.
+
+        Args:
+            parsed_pad: The padding string as produced by the grammar parser
+                        (or translated by ``_preprocess_sequence``).
+            zfill:      The numeric width implied by *parsed_pad*.
+            pad_style:  The active padding style for this sequence.
+
+        Returns:
+            The padding string that should be stored as the canonical form.
+        """
+        return parsed_pad
 
     def _postprocess_sequence(self, sequence: str) -> str:
         """Override to translate the assembled sequence string back to custom syntax.

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -247,7 +247,7 @@ class BaseFileSequence(typing.Generic[T]):
         """
         return sequence
 
-    def _resolve_padding(self, parsed_pad: str, zfill: int, pad_style) -> str:
+    def _resolve_padding(self, parsed_pad: str, zfill: int, pad_style: constants._PadStyle) -> str:
         """
         Normalize the padding string after parsing.
 

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -1847,6 +1847,32 @@ class BaseFileSequence(typing.Generic[T]):
             pad = cls.getPaddingChars(num, pad_style=pad_style)
         return pad
 
+    @classmethod
+    def parsePadding(cls, sequence: str) -> str:
+        """
+        Parse the padding characters out of an arbitrary sequence-like string.
+
+        Unlike constructing a full sequence instance, this does not require
+        *sequence* to represent a complete, valid sequence (e.g. no frame
+        range is required). It only reports the padding token, if any, that
+        can be identified. This is useful for answering "does this string
+        contain a padding token" for strings that may not be well-formed
+        sequences on their own, such as a single file path.
+
+        Override in a subclass alongside ``_preprocess_sequence`` to also
+        recognize a custom padding token that isn't understood on its own.
+
+        Args:
+            sequence (str): the sequence or path string to inspect
+
+        Returns:
+            str: the detected padding characters, or '' if none were found
+        """
+        try:
+            return parse_sequence_string(utils.asString(sequence)).padding
+        except ValueError:
+            return ''
+
 
 class FileSequence(BaseFileSequence[str]):
     """:class:`FileSequence` represents an ordered sequence of files as strings.

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2891,9 +2891,8 @@ class TestFindWithKlass(TestBase):
     """Test the klass argument on filesystem find methods."""
 
     class VRayFileSequence(FileSequence):
-        """Translates VRay <frameNN> padding tokens in both directions."""
+        """Translates VRay <frameNN> padding tokens using _resolve_padding."""
         _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
-        _PRINTF_PAD_RE = re.compile(r'%0?(\d+)d')
 
         def _preprocess_sequence(self, sequence):
             def replace(m):
@@ -2901,10 +2900,17 @@ class TestFindWithKlass(TestBase):
                 return '%0{}d'.format(width) if width > 0 else '%d'
             return self._VRAY_PAD_RE.sub(replace, sequence)
 
-        def _postprocess_sequence(self, sequence):
-            def replace(m):
-                return '<frame{:02d}>'.format(int(m.group(1)))
-            return self._PRINTF_PAD_RE.sub(replace, sequence)
+        def _resolve_padding(self, parsed_pad, zfill, pad_style):
+            if zfill > 0:
+                return '<frame{:02d}>'.format(zfill)
+            return parsed_pad
+
+        @classmethod
+        def getPaddingNum(cls, chars, **kwargs):
+            m = cls._VRAY_PAD_RE.match(chars)
+            if m:
+                return int(m.group(1))
+            return super().getPaddingNum(chars, **kwargs)
 
     # --- findSequencesOnDisk ---
 
@@ -2948,7 +2954,7 @@ class TestFindWithKlass(TestBase):
 
     def testFindSequenceOnDiskKlassVRayPattern(self):
         """_preprocess_sequence translates the VRay pattern before scanning,
-        and _postprocess_sequence restores it in str() output."""
+        and _resolve_padding stores the canonical token so str() returns it directly."""
         seq = FileSequence.findSequenceOnDisk(
             'seq/foo.<frame04>.exr',
             strictPadding=True,
@@ -2956,8 +2962,88 @@ class TestFindWithKlass(TestBase):
             klass=self.VRayFileSequence,
         )
         self.assertIsInstance(seq, self.VRayFileSequence)
-        self.assertEqual('%04d', seq.padding())
+        self.assertEqual('<frame04>', seq.padding())
         self.assertEqual('seq/foo.1-5<frame04>.exr', str(seq))
+
+
+class TestResolvePadding(TestBase):
+    """Test the _resolve_padding hook for canonical padding storage."""
+
+    class VRayFileSequence(FileSequence):
+        """Three-override VRay subclass: preprocess + resolve_padding + getPaddingNum."""
+        _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+
+        def _preprocess_sequence(self, sequence):
+            def replace(m):
+                width = int(m.group(1))
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._VRAY_PAD_RE.sub(replace, sequence)
+
+        def _resolve_padding(self, parsed_pad, zfill, pad_style):
+            if zfill > 0:
+                return '<frame{:02d}>'.format(zfill)
+            return parsed_pad
+
+        @classmethod
+        def getPaddingNum(cls, chars, **kwargs):
+            m = cls._VRAY_PAD_RE.match(chars)
+            if m:
+                return int(m.group(1))
+            return super().getPaddingNum(chars, **kwargs)
+
+    def testPaddingReturnedAsVRayToken(self):
+        """padding() returns the VRay token, not the printf form."""
+        seq = self.VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+        self.assertEqual('<frame04>', seq.padding())
+        self.assertEqual(4, seq.zfill())
+
+    def testStrUsesVRayToken(self):
+        """str() includes the VRay token without any _postprocess_sequence."""
+        seq = self.VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+        self.assertEqual('/render/beauty.1-100<frame04>.exr', str(seq))
+
+    def testFrameResolvesCorrectly(self):
+        """frame() still produces the correct zero-padded path."""
+        seq = self.VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+        self.assertEqual('/render/beauty.0042.exr', seq.frame(42))
+
+    def testSetPaddingWithVRayToken(self):
+        """setPadding('<frame02>') updates padding and frame() correctly."""
+        seq = self.VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+        seq.setPadding('<frame02>')
+        self.assertEqual('<frame02>', seq.padding())
+        self.assertEqual(2, seq.zfill())
+        self.assertEqual('/render/beauty.42.exr', seq.frame(42))
+
+    def testSetPaddingWithPrintfStored(self):
+        """setPadding('%04d') stores '%04d' as-is — no auto-normalisation via the setter."""
+        seq = self.VRayFileSequence('/render/beauty.1-100<frame04>.exr')
+        seq.setPadding('%04d')
+        self.assertEqual('%04d', seq.padding())
+
+    def testPatternOnly(self):
+        """Pattern-only sequence: padding() returns the VRay token."""
+        seq = self.VRayFileSequence('/render/beauty.<frame04>.exr')
+        self.assertEqual('<frame04>', seq.padding())
+        self.assertEqual(4, seq.zfill())
+        self.assertEqual('', seq.frameRange())
+
+    def testSubframes(self):
+        """Subframe sequence: both framePadding() and subframePadding() return VRay tokens."""
+        seq = self.VRayFileSequence(
+            '/render/beauty.1-5<frame04>.10-20<frame04>.exr',
+            allow_subframes=True,
+        )
+        self.assertEqual('<frame04>', seq.framePadding())
+        self.assertEqual('<frame04>', seq.subframePadding())
+        self.assertEqual(4, seq.zfill())
+        self.assertEqual(4, seq.decimalPlaces())
+
+    def testNoopDefault(self):
+        """Default _resolve_padding is a no-op — existing behaviour is preserved."""
+        seq = FileSequence('/render/beauty.1-100#.exr')
+        self.assertEqual('#', seq.padding())
+        self.assertEqual('#', seq._resolve_padding('#', 4, seq._pad_style))
 
 
 if __name__ == '__main__':

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2893,15 +2893,19 @@ class TestFindWithKlass(TestBase):
     class VRayFileSequence(FileSequence):
         """Translates VRay <frameNN> padding tokens using _resolve_padding."""
         _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+        _used_custom_padding = False
 
         def _preprocess_sequence(self, sequence):
             def replace(m):
                 width = int(m.group(1))
+                self._used_custom_padding = True
                 return '%0{}d'.format(width) if width > 0 else '%d'
             return self._VRAY_PAD_RE.sub(replace, sequence)
 
         def _resolve_padding(self, parsed_pad, zfill, pad_style):
-            if zfill > 0:
+            # Only apply the custom token if preprocessing actually saw one.
+            # A standard token of the same width must be left alone.
+            if zfill > 0 and self._used_custom_padding:
                 return '<frame{:02d}>'.format(zfill)
             return parsed_pad
 
@@ -2972,15 +2976,19 @@ class TestResolvePadding(TestBase):
     class VRayFileSequence(FileSequence):
         """Three-override VRay subclass: preprocess + resolve_padding + getPaddingNum."""
         _VRAY_PAD_RE = re.compile(r'<frame(\d+)>')
+        _used_custom_padding = False
 
         def _preprocess_sequence(self, sequence):
             def replace(m):
                 width = int(m.group(1))
+                self._used_custom_padding = True
                 return '%0{}d'.format(width) if width > 0 else '%d'
             return self._VRAY_PAD_RE.sub(replace, sequence)
 
         def _resolve_padding(self, parsed_pad, zfill, pad_style):
-            if zfill > 0:
+            # Only apply the custom token if preprocessing actually saw one.
+            # A standard token of the same width must be left alone.
+            if zfill > 0 and self._used_custom_padding:
                 return '<frame{:02d}>'.format(zfill)
             return parsed_pad
 
@@ -3040,10 +3048,101 @@ class TestResolvePadding(TestBase):
         self.assertEqual(4, seq.decimalPlaces())
 
     def testNoopDefault(self):
-        """Default _resolve_padding is a no-op — existing behaviour is preserved."""
+        """Default _resolve_padding is a no-op — existing behavior is preserved."""
         seq = FileSequence('/render/beauty.1-100#.exr')
         self.assertEqual('#', seq.padding())
         self.assertEqual('#', seq._resolve_padding('#', 4, seq._pad_style))
+
+
+class TestPaddingExtensionAcceptance(TestBase):
+    """End-to-end example combining all four subclass extension points:
+    _preprocess_sequence, _resolve_padding, getPaddingNum, and parsePadding.
+
+    A custom padding token must only be recognized when the subclass itself
+    saw and translated it during preprocessing: a standard token that
+    happens to imply the same width must not be reinterpreted as the custom
+    one. parsePadding must also be able to report whether a padding token is
+    present in a string that is not itself a complete, valid sequence.
+    """
+
+    class VRayFileSequence(FileSequence):
+        """Subclass with extra padding syntax support, on top of the
+        standard fileseq tokens (e.g. '#', '@', '%04d')."""
+        _CUSTOM_PAD_RE = re.compile(r'<frame(\d+)>')
+        _used_custom_padding = False
+
+        def _preprocess_sequence(self, sequence):
+            def replace(m):
+                width = int(m.group(1))
+                self._used_custom_padding = True
+                return '%0{}d'.format(width) if width > 0 else '%d'
+            return self._CUSTOM_PAD_RE.sub(replace, sequence)
+
+        @classmethod
+        def getPaddingNum(cls, chars, **kwargs):
+            m = cls._CUSTOM_PAD_RE.match(chars)
+            if m:
+                return int(m.group(1))
+            return super().getPaddingNum(chars, **kwargs)
+
+        def _resolve_padding(self, parsed_pad, zfill, pad_style):
+            # Only apply the custom token if this instance's preprocessing
+            # step actually saw and translated one. A standard token that
+            # happens to imply the same width must be left alone.
+            if zfill > 0 and self._used_custom_padding:
+                return '<frame{:02d}>'.format(zfill)
+            return super()._resolve_padding(parsed_pad, zfill, pad_style)
+
+        @classmethod
+        def parsePadding(cls, sequence):
+            padding = super().parsePadding(sequence)
+            if not padding:
+                m = cls._CUSTOM_PAD_RE.search(sequence)
+                if m:
+                    padding = m.group(0)
+            return padding
+
+    @classmethod
+    def has_padding(cls, path):
+        """Return whether the path contains any padding token at all."""
+        return bool(cls.VRayFileSequence.parsePadding(path))
+
+    def testCustomTokenPadding(self):
+        """A custom padding token round-trips through padding() and frame()."""
+        seq = self.VRayFileSequence('/render/beauty.<frame04>.exr')
+        self.assertEqual('<frame04>', seq.padding())
+        self.assertEqual('/render/beauty.0042.exr', seq.frame(42))
+        seq.setPadding('<frame02>')
+        self.assertEqual('/render/beauty.42.exr', seq.frame(42))
+
+    def testStandardTokenPaddingIsNotReinterpreted(self):
+        """A standard '#' token must not be converted to the custom token
+        just because its implied width happens to match."""
+        seq = self.VRayFileSequence('/render/beauty.#.exr')
+        self.assertEqual('#', seq.padding())
+        self.assertEqual('/render/beauty.0042.exr', seq.frame(42))
+        seq.setPadding('%02d')
+        self.assertEqual('/render/beauty.42.exr', seq.frame(42))
+
+    def testHasPaddingCustomToken(self):
+        """has_padding recognizes the custom token."""
+        self.assertTrue(self.has_padding('/render/beauty.<frame04>.exr'))
+
+    def testHasPaddingStandardToken(self):
+        """has_padding recognizes standard fileseq padding tokens."""
+        self.assertTrue(self.has_padding('/render/beauty.#.exr'))
+
+    def testHasPaddingNoToken(self):
+        """has_padding is False when there is no padding token at all."""
+        self.assertFalse(self.has_padding('/render/beauty.exr'))
+
+    def testHasPaddingResolvedFrameNumber(self):
+        """A resolved frame number is not itself a padding token."""
+        self.assertFalse(self.has_padding('/render/beauty.1001.exr'))
+
+    def testHasPaddingUnrelatedText(self):
+        """Unrelated text is not mistaken for a padding token."""
+        self.assertFalse(self.has_padding('/render/beauty.xyz.exr'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `padding()` method previously always returned the grammar-normalised form (e.g. %04d) even when a subclass   
  translated a custom token on input. There was no hook to store the custom form as the canonical             
  representation. This adds `_resolve_padding` to close that gap.  

  - Adds `_resolve_padding(parsed_pad, zfill, pad_style)` hook to `BaseFileSequence`, called after `_zfill` is   
  computed during init
  - Subclasses can override it to store a custom padding token as the canonical form, so `padding()` and `str()` 
  return it directly without needing `_postprocess_sequence`                                                     
  - Updates `TestFindWithKlass.VRayFileSequence` to use the new pattern; adds `TestResolvePadding` test class
  - Updates `docs/usage.rst` with the three-override VRay example and a new `_resolve_padding` section      

Refs #139 