### PR TITLE
Prevent catastrophic regex backtracking by escaping input to glob-to-regex function (refs #161)

### DIFF
--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -1582,7 +1582,14 @@ class BaseFileSequence(typing.Generic[T]):
     def _globCharsToRegex(filename: str) -> str:
         """
         Translate single character elements of a shell pattern to make suitable
-        for a regular expression pattern
+        for a regular expression pattern.
+
+        Only the documented glob syntax (``?``, ``*``, and the brace-group
+        syntax ``{foo,bar}``) is treated as meaningful. Every other character
+        is escaped so it is always matched literally, even if it happens to
+        be a regex metacharacter (e.g. ``(``, ``)``, ``+``, ``|``, ``$``).
+        Without this, a caller-supplied "glob" pattern could inject live
+        regex syntax and trigger catastrophic backtracking (ReDoS).
 
         Args:
             filename (str): filename containing shell pattern to convert
@@ -1590,10 +1597,19 @@ class BaseFileSequence(typing.Generic[T]):
         Returns:
             str:
         """
-        filename = filename.replace('.', r'\.')
-        filename = filename.replace('*', '.*')
-        filename = filename.replace('?', '.')
-        return filename
+        # re.escape() prefixes every regex-special character with a single
+        # backslash, so each "\X" pair in its output maps 1:1 back to one
+        # original character. That makes it safe to replace those pairs
+        # with the glob equivalents afterward, without risk of matching
+        # across the boundary of two different original characters.
+        escaped = re.escape(filename)
+        escaped = escaped.replace(r'\*', '.*')
+        escaped = escaped.replace(r'\?', '.')
+        # Left as literal markers for the brace-group alternation
+        # post-processing (see findSequencesOnDisk).
+        escaped = escaped.replace(r'\{', '{')
+        escaped = escaped.replace(r'\}', '}')
+        return escaped
 
     class _FilterByPaddingNum(object):
         def __init__(self) -> None:

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -11,13 +11,17 @@ with warnings.catch_warnings():
 
 from decimal import Decimal
 import json
+import multiprocessing
 import operator
 import os
 import pathlib
 import pickle
 import re
+import shutil
 import string
 import sys
+import tempfile
+import time
 import unittest
 from collections import namedtuple
 
@@ -70,6 +74,24 @@ def _getCommonPathSep(path):
 
 
 # No longer need to mock _getPathSep - it now detects separators natively
+
+
+def _findSequencesOnDiskWorker(klass, pattern, queue):
+    """
+    multiprocessing target for testGlobPatternRegexInjection: runs
+    findSequencesOnDisk() in a subprocess so the test can enforce a hard
+    timeout instead of hanging if the pattern triggers catastrophic regex
+    backtracking.
+
+    :type klass: type
+    :param klass: FileSequence or FilePathSequence
+    :type pattern: str
+    :param pattern: glob-like pattern to search
+    :type queue: multiprocessing.Queue
+    :param queue: signaled once findSequencesOnDisk() returns
+    """
+    klass.findSequencesOnDisk(pattern)
+    queue.put(True)
 
 
 class TestUtils(unittest.TestCase):
@@ -952,6 +974,27 @@ class AbstractBaseTests:
             self.assertEqual('.exr', seq.extension())
             self.assertEqual('', seq.padding())
             self.assertEqual('', seq.frameRange())
+
+        def testConstructorNotVulnerableToBraceReDoS(self):
+            """Issue 161 PoC: constructor must not be vulnerable to catastrophic
+            backtracking via brace patterns.
+
+            The reported proof-of-concept claimed FileSequence(payload) hangs on
+            a crafted "{a?a?...}" brace payload. The brace-to-regex conversion
+            only exists in findSequencesOnDisk(), not in the constructor, so
+            this must return near-instantly and treat the payload as literal
+            text (see testGlobPatternRegexInjection for the actual vulnerable
+            code path).
+            """
+            FS = self.FS
+            payload = "a" * 30 + "{" + "a?" * 30 + "}"
+
+            start = time.time()
+            seq = FS(payload)
+            elapsed = time.time() - start
+
+            self.assertLess(elapsed, 1.0)
+            self.assertEqual(payload, str(seq))
 
         def testEqual(self):
             @dataclasses.dataclass
@@ -2274,6 +2317,46 @@ class AbstractBaseTests:
                 actual = self.toNormpaths([str(s) for s in actual])
                 expected = self.toNormpaths(expected)
                 self.assertEqual(expected, actual)
+
+        def testGlobPatternRegexInjection(self):
+            """Issue 161 - pattern argument must not allow regex injection / ReDoS.
+
+            Only ``? * {foo,bar}`` are documented as meaningful glob syntax; any
+            other regex metacharacter (e.g. ``( ) + $``) in the pattern must be
+            treated as a literal character, not compiled as live regex syntax.
+            """
+            tmpdir = tempfile.mkdtemp()
+            try:
+                # Filename does NOT match the crafted pattern below, forcing
+                # maximal backtracking if "(a+)+" leaks through as regex syntax.
+                fname = "a" * 30 + "X.ext"
+                with open(os.path.join(tmpdir, fname), "w"):
+                    pass
+
+                evil_pattern = os.path.join(tmpdir, "(a+)+$.ext")
+                timeout_secs = 3
+
+                queue = multiprocessing.Queue()
+                proc = multiprocessing.Process(
+                    target=_findSequencesOnDiskWorker,
+                    args=(self.FS, evil_pattern, queue))
+                proc.start()
+                proc.join(timeout_secs)
+
+                hung = proc.is_alive()
+                if hung:
+                    proc.terminate()
+                    proc.join()
+
+                self.assertFalse(
+                    hung,
+                    "findSequencesOnDisk() did not return within {}s; regex "
+                    "metacharacters in the pattern argument are not escaped "
+                    "before compilation, allowing catastrophic backtracking"
+                    .format(timeout_secs)
+                )
+            finally:
+                shutil.rmtree(tmpdir, ignore_errors=True)
 
 
     class BaseTestFindSequenceOnDisk(TestBase):


### PR DESCRIPTION
Refs #161 